### PR TITLE
Improve login/register forms

### DIFF
--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,72 +1,44 @@
 // src/pages/Register.jsx
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useNotifications } from '../components/NotificationProvider';
 import '../styles/register.scss';
 
-const GOOGLE_CLIENT_ID = '477836153268-gmsf092g4nprn297cov055if8n66reel.apps.googleusercontent.com'; // replace with real client ID
-
 const Register = () => {
   const { showNotification } = useNotifications();
-  const [twofaToken, setTwofaToken] = useState(null);
-  const [code, setCode] = useState('');
   const navigate = useNavigate();
+  const [form, setForm] = useState({ username: '', email: '', password: '' });
+  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (window.google && !twofaToken) {
-      window.google.accounts.id.initialize({
-        client_id: GOOGLE_CLIENT_ID,
-        callback: handleGoogle,
-      });
-      window.google.accounts.id.renderButton(
-        document.getElementById('google-btn'),
-        { theme: 'outline', size: 'large' }
-      );
-    }
-  }, [twofaToken]);
-
-  const handleGoogle = async (resp) => {
-    showNotification({ type: 'info', message: 'Processing...' });
-    try {
-      const res = await fetch('https://app.byxbot.com/php/google_start.php', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ id_token: resp.credential, mode: 'register' }),
-      });
-      const data = await res.json();
-      if (res.ok && data.token) {
-        setTwofaToken(data.token);
-        showNotification({ type: 'info', message: 'Verification code sent.' });
-      } else {
-        showNotification({ type: 'error', message: data.message || 'Error' });
-      }
-    } catch (err) {
-      showNotification({ type: 'error', message: err.message });
-    }
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setLoading(true);
+    showNotification({ type: 'info', message: 'Registering...' });
     try {
-      const res = await fetch('https://app.byxbot.com/php/verify_code.php', {
+      const res = await fetch('https://app.byxbot.com/php/register.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ token: twofaToken, code }),
+        body: JSON.stringify(form),
       });
       const data = await res.json();
       if (res.ok) {
         localStorage.setItem('authToken', 'loggedIn');
-        localStorage.setItem('user', JSON.stringify(data.user));
-        showNotification({ type: 'success', message: 'Registration complete.' });
+        localStorage.setItem('user', JSON.stringify({ id: data.user_id, username: form.username, email: form.email }));
+        showNotification({ type: 'success', message: 'Registration successful.' });
         setTimeout(() => navigate('/'), 1000);
       } else {
-        showNotification({ type: 'error', message: data.message || 'Invalid code' });
+        showNotification({ type: 'error', message: data.message || 'Registration error' });
       }
     } catch (err) {
       showNotification({ type: 'error', message: err.message });
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -74,23 +46,41 @@ const Register = () => {
     <div className="auth-page">
       <div className="auth-card">
         <h2>Register</h2>
-        {!twofaToken ? (
-          <div id="google-btn" className="google-btn"></div>
-        ) : (
-          <form onSubmit={handleSubmit} className="auth-form">
-            <label>
-              2FA Code
-              <input
-                type="text"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                maxLength={6}
-                required
-              />
-            </label>
-            <button type="submit" className="btn-primary">Verify</button>
-          </form>
-        )}
+        <form onSubmit={handleSubmit} className="auth-form">
+          <label>
+            Username
+            <input
+              name="username"
+              type="text"
+              value={form.username}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            Email
+            <input
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            Password
+            <input
+              name="password"
+              type="password"
+              value={form.password}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <button type="submit" className="btn-primary" disabled={loading}>
+            {loading ? 'Please wait…' : 'Register'}
+          </button>
+        </form>
         <p className="switch-link">
           Already have an account? <Link to="/login">Go to Login</Link>
         </p>

--- a/src/styles/login.scss
+++ b/src/styles/login.scss
@@ -6,15 +6,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #1c92d2, #f2fcfe);
+  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+  padding: 2rem;
 }
 
 .auth-card {
-  width: 380px;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(12px);
+  width: 420px;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(16px);
   border-radius: 1rem;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
   padding: 2.5rem;
   color: #fff;
   display: flex;

--- a/src/styles/register.scss
+++ b/src/styles/register.scss
@@ -6,15 +6,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #1c92d2, #f2fcfe);
+  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+  padding: 2rem;
 }
 
 .auth-card {
-  width: 380px;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(12px);
+  width: 420px;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(16px);
   border-radius: 1rem;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
   padding: 2.5rem;
   color: #fff;
   display: flex;


### PR DESCRIPTION
## Summary
- simplify login and registration pages with regular forms
- improve styling of auth pages

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6866ecbad154832ca200c553b4bded6d