### PR TITLE
Fix Google register and persistent sessions

### DIFF
--- a/php/accept_waitlist.php
+++ b/php/accept_waitlist.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 1) Session & user verification (owner of the Whop)
-session_start();
+require_once __DIR__ . '/session_init.php';
 $owner_id = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : 0;
 if ($owner_id <= 0) {
     http_response_code(401);

--- a/php/ban_user.php
+++ b/php/ban_user.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ——————————————————————————————————————————————
 // 2) Session & authentication
 // ——————————————————————————————————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/campaign.php
+++ b/php/campaign.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/cancel_membership.php
+++ b/php/cancel_membership.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 3) Session & authorization
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/chat/fetch_messages.php
+++ b/php/chat/fetch_messages.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 header("Content-Type: application/json; charset=UTF-8");
-session_start();
+require_once __DIR__ . '/../session_init.php';
 if (empty($_SESSION['user_id'])) {
     http_response_code(401);
     echo json_encode(["status" => "error", "message" => "Unauthorized"]);

--- a/php/chat/list_whops.php
+++ b/php/chat/list_whops.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 header("Content-Type: application/json; charset=UTF-8");
-session_start();
+require_once __DIR__ . '/../session_init.php';
 $user_id = $_SESSION['user_id'] ?? 0;
 if ($user_id <= 0) {
     http_response_code(401);

--- a/php/chat/react_message.php
+++ b/php/chat/react_message.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 header("Content-Type: application/json; charset=UTF-8");
-session_start();
+require_once __DIR__ . '/../session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/chat/send_message.php
+++ b/php/chat/send_message.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 header("Content-Type: application/json; charset=UTF-8");
-session_start();
+require_once __DIR__ . '/../session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/delete_whop.php
+++ b/php/delete_whop.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 3) Session & authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/deposit.php
+++ b/php/deposit.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 3) SESSION – authentication check
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/deposit_history.php
+++ b/php/deposit_history.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/expire_campaign.php
+++ b/php/expire_campaign.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/fetch_submissions_by_campaign.php
+++ b/php/fetch_submissions_by_campaign.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // Session authorization
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/get_dashboard_data.php
+++ b/php/get_dashboard_data.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ════════════════════════════════════════════════
 // 2) Session & user authentication
 // ════════════════════════════════════════════════
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id_raw = $_SESSION['user_id'] ?? null;
 if (!$user_id_raw) {
     http_response_code(401);

--- a/php/get_joined_whops.php
+++ b/php/get_joined_whops.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ---------------------------------------------------
 // 2) Session & authentication check
 // ---------------------------------------------------
-session_start();
+require_once __DIR__ . '/session_init.php';
 $userId = $_SESSION['user_id'] ?? null;
 if (!$userId) {
     http_response_code(401);

--- a/php/get_memberships.php
+++ b/php/get_memberships.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ——————————————————
 // 2) Session + auth check
 // ——————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/get_memberships2.php
+++ b/php/get_memberships2.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // —————————————————————————————
 // 2) Session & authentication check
 // —————————————————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/get_payments.php
+++ b/php/get_payments.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/get_user_whops.php
+++ b/php/get_user_whops.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // =========================================
 // Session
 // =========================================
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/get_whop.php
+++ b/php/get_whop.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // =========================================
 // 1) Session & user authentication
 // =========================================
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : 0;
 if ($user_id <= 0) {
     http_response_code(401);

--- a/php/get_whop_members.php
+++ b/php/get_whop_members.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ——————————————————————————————————————————————————————————
 // 2) Session & user check
 // ——————————————————————————————————————————————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/google_start.php
+++ b/php/google_start.php
@@ -84,7 +84,9 @@ if ($res && $res->num_rows > 0) {
     // create new user during registration
     $username = generateUniqueUsername($conn, $email);
     $usernameEsc = $conn->real_escape_string($username);
-    $insertSql = "INSERT INTO users4 (username, email, password_hash, balance) VALUES ('$usernameEsc', '$emailEsc', NULL, 0)";
+    $dummyPass = bin2hex(random_bytes(16));
+    $dummyHash = $conn->real_escape_string(password_hash($dummyPass, PASSWORD_BCRYPT));
+    $insertSql = "INSERT INTO users4 (username, email, password_hash, balance) VALUES ('$usernameEsc', '$emailEsc', '$dummyHash', 0)";
     if ($conn->query($insertSql) !== TRUE) {
         http_response_code(500);
         echo json_encode(['status' => 'error', 'message' => 'Error creating user: ' . $conn->error]);

--- a/php/invite_moderator.php
+++ b/php/invite_moderator.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ──────────────────────────────────────────────────────────────────────────────
 // 2) Session & user authentication
 // ──────────────────────────────────────────────────────────────────────────────
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/join_membership.php
+++ b/php/join_membership.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ——————————————————————————————————————————————————————————
 // 2) Session & authorization
 // ——————————————————————————————————————————————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/join_waitlist.php
+++ b/php/join_waitlist.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // Session and authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/join_whop.php
+++ b/php/join_whop.php
@@ -25,7 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & user authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/leave_whop.php
+++ b/php/leave_whop.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & authorization
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/login.php
+++ b/php/login.php
@@ -14,26 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
-/**
- * === 2) PHP SESSION COOKIE PARAMS ===
- * ONLY HERE, BEFORE session_start(), we call session_set_cookie_params.
- * Here we define:
- *   - 'secure'   => true  (required if the page is served over HTTPS; set to false if not using HTTPS)
- *   - 'samesite' => 'None' (required for cross-domain, otherwise the cookie from localhost:3000
- *                           will not be sent to app.byxbot.com)
- */
-$cookieParams = session_get_cookie_params();
-session_set_cookie_params([
-    'lifetime' => $cookieParams['lifetime'],
-    'path'     => $cookieParams['path'],
-    'domain'   => $cookieParams['domain'], // can be an empty string for the current host
-    'secure'   => true,    // true if your PHP is indeed on HTTPS; change to false otherwise
-    'httponly' => true,
-    'samesite' => 'None'
-]);
-
-session_start();
-// ======================= end SESSION cookie configuration =======================
+require_once __DIR__ . '/session_init.php';
 
 // Database connection
 require_once __DIR__ . '/config_login.php';

--- a/php/logout.php
+++ b/php/logout.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
-session_start();
+require_once __DIR__ . '/session_init.php';
 session_unset();
 session_destroy();
 

--- a/php/moderate_submission.php
+++ b/php/moderate_submission.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session handling
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/profile.php
+++ b/php/profile.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 header("Content-Type: application/json; charset=UTF-8");
-session_start();
+require_once __DIR__ . '/session_init.php';
 
 // Check authentication
 $user_id = $_SESSION['user_id'] ?? null;

--- a/php/refund_payment.php
+++ b/php/refund_payment.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & user authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $currentUserId = $_SESSION['user_id'] ?? null;
 if (!$currentUserId) {
     http_response_code(401);

--- a/php/register.php
+++ b/php/register.php
@@ -14,7 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit();
 }
 
-session_start(); // If you use sessions for anything
+require_once __DIR__ . '/session_init.php'; // If you use sessions for anything
 
 // 2) Connect to the database
 require_once __DIR__ . '/config_login.php';

--- a/php/reject_waitlist.php
+++ b/php/reject_waitlist.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & user authentication (must be the owner)
-session_start();
+require_once __DIR__ . '/session_init.php';
 $owner_id = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : 0;
 if ($owner_id <= 0) {
     http_response_code(401);

--- a/php/remove_member.php
+++ b/php/remove_member.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ——————————————————————————————————————————————————————————————
 // 2) Session and user authentication
 // ——————————————————————————————————————————————————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/remove_moderator.php
+++ b/php/remove_moderator.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session and user authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id_raw = $_SESSION['user_id'] ?? null;
 if (!$user_id_raw) {
     http_response_code(401);

--- a/php/request_waitlist.php
+++ b/php/request_waitlist.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // ——————————————————————————————————————————————————————————————
 // 2) Session + authentication
 // ——————————————————————————————————————————————————————————————
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/session_init.php
+++ b/php/session_init.php
@@ -1,0 +1,13 @@
+<?php
+$cookieParams = session_get_cookie_params();
+session_set_cookie_params([
+    'lifetime' => 60 * 60 * 24 * 30, // 30 days
+    'path'     => $cookieParams['path'],
+    'domain'   => $cookieParams['domain'],
+    'secure'   => true,
+    'httponly' => true,
+    'samesite' => 'None',
+]);
+ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 30);
+session_start();
+?>

--- a/php/submissions.php
+++ b/php/submissions.php
@@ -23,7 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 header("Content-Type: application/json; charset=UTF-8");
 
 // 2) Authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/subscribe_whop.php
+++ b/php/subscribe_whop.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & user authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/unban_user.php
+++ b/php/unban_user.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 2) Session & user authentication
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/update_whop.php
+++ b/php/update_whop.php
@@ -61,7 +61,7 @@ if (json_last_error() !== JSON_ERROR_NONE) {
 }
 
 // 7) Session & user validation
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/update_whop_slug.php
+++ b/php/update_whop_slug.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 3) Start session and verify user is logged in
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/upload_avatar.php
+++ b/php/upload_avatar.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 3) Start session to identify the user
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/upload_whop_image.php
+++ b/php/upload_whop_image.php
@@ -47,7 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 // 6) Start session and verify user is logged in
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/verify_code.php
+++ b/php/verify_code.php
@@ -35,17 +35,8 @@ function generateUniqueUsername(mysqli $conn, string $email): string {
     return $username;
 }
 
-$cookieParams = session_get_cookie_params();
-session_set_cookie_params([
-    'lifetime' => 60 * 60 * 24 * 30, // 30 days
-    'path'     => $cookieParams['path'],
-    'domain'   => $cookieParams['domain'],
-    'secure'   => true,
-    'httponly' => true,
-    'samesite' => 'None'
-]);
 
-session_start();
+require_once __DIR__ . '/session_init.php';
 
 $inputJSON = file_get_contents('php://input');
 $data = json_decode($inputJSON, true);

--- a/php/whop.php
+++ b/php/whop.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // =========================================
 // Session to determine user_id
 // =========================================
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/withdraw.php
+++ b/php/withdraw.php
@@ -24,7 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);

--- a/php/withdraw_history.php
+++ b/php/withdraw_history.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit();
 }
 
-session_start();
+require_once __DIR__ . '/session_init.php';
 $user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     http_response_code(401);


### PR DESCRIPTION
## Summary
- fix Google registration by inserting a random password hash
- create `session_init.php` to configure PHP sessions for 30 days
- use the new session initializer across all PHP endpoints

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f33dbaf8832c8dee09f01ad074fc