### PR TITLE
Fix DB host for wallet setup

### DIFF
--- a/solana-monitor/monitor.js
+++ b/solana-monitor/monitor.js
@@ -37,7 +37,7 @@ import {
 
 // MySQL připojení
 const dbConfig = {
-  host: '127.0.0.1',
+  host: 'localhost',
   user: 'dbadmin',
   password: '3otwj3zR6EI',
   database: 'byx',

--- a/solana-monitor/setup_deposit_addresses.js
+++ b/solana-monitor/setup_deposit_addresses.js
@@ -16,7 +16,7 @@ import bs58 from 'bs58';
 
 // --- 1) Konfigurace připojení k DB ---
 const dbConfig = {
-  host: '127.0.0.1',     // nikoli "localhost", ale 127.0.0.1
+  host: 'localhost',
   user: 'dbadmin',
   password: '3otwj3zR6EI',
   database: 'byx',


### PR DESCRIPTION
## Summary
- update Solana monitor scripts to use `localhost` for MySQL

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867f8f203cc832cb7da27687c4cc968