### PR TITLE
Add JWT-based auth fallback

### DIFF
--- a/php/login.php
+++ b/php/login.php
@@ -15,6 +15,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 require_once __DIR__ . '/session_init.php';
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/utils.php';
 
 // Database connection
 require_once __DIR__ . '/config_login.php';
@@ -71,13 +73,15 @@ if (!password_verify($password, $hash)) {
 $_SESSION['user_id'] = $user['id'];
 
 // Return JSON with user info
+$jwt = generate_jwt((int)$user['id']);
 $response = [
     "status" => "success",
-    "user" => [
+    "user"   => [
         "id"       => $user['id'],
         "username" => $user['username'],
         "email"    => $user['email']
-    ]
+    ],
+    "token"  => $jwt
 ];
 echo json_encode($response);
 $conn->close();

--- a/php/session_init.php
+++ b/php/session_init.php
@@ -10,4 +10,22 @@ session_set_cookie_params([
 ]);
 ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 30);
 session_start();
+
+// --- Optional JWT auth fallback ---
+if (!isset($_SESSION['user_id']) && isset($_SERVER['HTTP_AUTHORIZATION'])) {
+    require_once __DIR__ . '/config.php';
+    require_once __DIR__ . '/vendor/autoload.php';
+    $auth = $_SERVER['HTTP_AUTHORIZATION'];
+    if (preg_match('/Bearer\s+(.*)/', $auth, $m)) {
+        $jwt = $m[1];
+        try {
+            $payload = Firebase\JWT\JWT::decode($jwt, new Firebase\JWT\Key(JWT_SECRET, 'HS256'));
+            if ($payload && isset($payload->sub) && $payload->exp >= time()) {
+                $_SESSION['user_id'] = (int)$payload->sub;
+            }
+        } catch (Exception $e) {
+            // ignore invalid token
+        }
+    }
+}
 ?>

--- a/php/verify_code.php
+++ b/php/verify_code.php
@@ -13,6 +13,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 require_once __DIR__ . '/config_login.php';
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/utils.php';
 
 function generateUniqueUsername(mysqli $conn, string $email): string {
     $base = explode('@', $email)[0];
@@ -116,9 +118,11 @@ if ($user) {
 
 $_SESSION['user_id'] = $userId;
 
+$jwt = generate_jwt($userId);
 $conn->close();
 
 echo json_encode([
     'status' => 'success',
-    'user' => $user
+    'user'   => $user,
+    'token'  => $jwt
 ]);

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -14,7 +14,8 @@ const ProtectedRoute = ({ children }) => {
   useEffect(() => {
     async function verify() {
       const token = localStorage.getItem('authToken');
-      if (!token) {
+      const jwt = localStorage.getItem('jwtToken');
+      if (!token || !jwt) {
         setLoggedIn(false);
         setChecking(false);
         return;
@@ -23,10 +24,10 @@ const ProtectedRoute = ({ children }) => {
       try {
         const res = await fetch('https://app.byxbot.com/php/profile.php', {
           method: 'GET',
-          credentials: 'include',
         });
         if (res.status === 401) {
           localStorage.removeItem('authToken');
+          localStorage.removeItem('jwtToken');
           setLoggedIn(false);
         } else {
           setLoggedIn(true);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,17 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+
+// Global fetch wrapper to attach JWT token
+const origFetch = window.fetch;
+window.fetch = (url, options = {}) => {
+  const opts = { ...options, credentials: 'include' };
+  opts.headers = { ...(options.headers || {}) };
+  const jwt = localStorage.getItem('jwtToken');
+  if (jwt) {
+    opts.headers['Authorization'] = `Bearer ${jwt}`;
+  }
+  return origFetch(url, opts);
+};
 import App from './App';
 import { ThemeProvider } from './context/ThemeContext';
 import { NotificationProvider } from './components/NotificationProvider';

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -64,6 +64,9 @@ const handleGoogle = async (resp) => {
       if (res.ok) {
         const username = data.user.username || data.user.email.split('@')[0];
         localStorage.setItem('authToken', 'loggedIn');
+        if (data.token) {
+          localStorage.setItem('jwtToken', data.token);
+        }
         localStorage.setItem('user', JSON.stringify({ ...data.user, username }));
         showNotification({ type: 'success', message: 'Login successful.' });
         setTimeout(() => navigate('/'), 1000);

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -240,6 +240,7 @@ export default function Profile() {
       .then(res => {
         if (res.ok) {
           localStorage.removeItem('authToken');
+          localStorage.removeItem('jwtToken');
           localStorage.removeItem('user');
           showNotification({ type:'info', message:'You have been logged out.' });
           navigate('/login');

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -60,6 +60,9 @@ const Register = () => {
       if (res.ok) {
         const username = data.user.username || data.user.email.split('@')[0];
         localStorage.setItem('authToken', 'loggedIn');
+        if (data.token) {
+          localStorage.setItem('jwtToken', data.token);
+        }
         localStorage.setItem('user', JSON.stringify({ ...data.user, username }));
         showNotification({ type: 'success', message: 'Registration complete.' });
         setTimeout(() => navigate('/'), 1000);


### PR DESCRIPTION
## Summary
- support JWT tokens in `session_init.php` for API authentication
- return JWT from `verify_code.php` and `login.php`
- store JWT in localStorage on login/register and remove on logout
- globally attach JWT via fetch wrapper in `src/index.js`
- check token in `ProtectedRoute`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686820a3c6cc832cb377c94b57cab406