### PR TITLE
Refreshed auth pages

### DIFF
--- a/src/components/TwoFactorCodeInput.jsx
+++ b/src/components/TwoFactorCodeInput.jsx
@@ -1,0 +1,38 @@
+import React, { useRef } from 'react';
+
+export default function TwoFactorCodeInput({ value, onChange }) {
+  const inputRefs = useRef([]);
+
+  const handleChange = (e, idx) => {
+    const val = e.target.value.replace(/\D/g, '').slice(-1);
+    const codeArr = [...value];
+    codeArr[idx] = val;
+    onChange(codeArr);
+    if (val && idx < 5) {
+      inputRefs.current[idx + 1].focus();
+    }
+  };
+
+  const handleKeyDown = (e, idx) => {
+    if (e.key === 'Backspace' && !value[idx] && idx > 0) {
+      inputRefs.current[idx - 1].focus();
+    }
+  };
+
+  return (
+    <div className="twofa-input">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <input
+          key={i}
+          type="text"
+          inputMode="numeric"
+          maxLength="1"
+          value={value[i] || ''}
+          onChange={(ev) => handleChange(ev, i)}
+          onKeyDown={(ev) => handleKeyDown(ev, i)}
+          ref={(el) => (inputRefs.current[i] = el)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useNotifications } from '../components/NotificationProvider';
+import TwoFactorCodeInput from '../components/TwoFactorCodeInput';
 import '../styles/login.scss';
 
 const GOOGLE_CLIENT_ID = '477836153268-gmsf092g4nprn297cov055if8n66reel.apps.googleusercontent.com'; // replace with real client ID
@@ -10,7 +11,7 @@ const GOOGLE_CLIENT_ID = '477836153268-gmsf092g4nprn297cov055if8n66reel.apps.goo
 const Login = () => {
   const { showNotification } = useNotifications();
   const [twofaToken, setTwofaToken] = useState(null);
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState(Array(6).fill(''));
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -58,7 +59,7 @@ const handleGoogle = async (resp) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ token: twofaToken, code }),
+        body: JSON.stringify({ token: twofaToken, code: code.join('') }),
       });
       const data = await res.json();
       if (res.ok) {
@@ -82,17 +83,9 @@ const handleGoogle = async (resp) => {
         {!twofaToken ? (
           <div id="google-btn" className="google-btn"></div>
         ) : (
-          <form onSubmit={handleSubmit} className="login-form">
-            <label>
-              2FA Code
-              <input
-                type="text"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                maxLength={6}
-                required
-              />
-            </label>
+          <form onSubmit={handleSubmit} className="auth-form">
+            <label>2FA Code</label>
+            <TwoFactorCodeInput value={code} onChange={setCode} />
             <button type="submit" className="btn-primary">Verify</button>
           </form>
         )}

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useNotifications } from '../components/NotificationProvider';
+import TwoFactorCodeInput from '../components/TwoFactorCodeInput';
 import '../styles/register.scss';
 
 const GOOGLE_CLIENT_ID = '477836153268-gmsf092g4nprn297cov055if8n66reel.apps.googleusercontent.com'; // replace with real client ID
@@ -10,7 +11,7 @@ const GOOGLE_CLIENT_ID = '477836153268-gmsf092g4nprn297cov055if8n66reel.apps.goo
 const Register = () => {
   const { showNotification } = useNotifications();
   const [twofaToken, setTwofaToken] = useState(null);
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState(Array(6).fill(''));
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -54,7 +55,7 @@ const Register = () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ token: twofaToken, code }),
+        body: JSON.stringify({ token: twofaToken, code: code.join('') }),
       });
       const data = await res.json();
       if (res.ok) {
@@ -78,17 +79,9 @@ const Register = () => {
         {!twofaToken ? (
           <div id="google-btn" className="google-btn"></div>
         ) : (
-          <form onSubmit={handleSubmit} className="register-form">
-            <label>
-              2FA Code
-              <input
-                type="text"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                maxLength={6}
-                required
-              />
-            </label>
+          <form onSubmit={handleSubmit} className="auth-form">
+            <label>2FA Code</label>
+            <TwoFactorCodeInput value={code} onChange={setCode} />
             <button type="submit" className="btn-primary">Verify</button>
           </form>
         )}

--- a/src/styles/login.scss
+++ b/src/styles/login.scss
@@ -6,64 +6,47 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(120deg, var(--primary-color), var(--secondary-color));
-  padding: 2rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.auth-page::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.15), transparent 70%),
-                    radial-gradient(circle at 80% 80%, rgba(255,255,255,0.1), transparent 70%);
-  animation: move 20s linear infinite;
-}
-
-@keyframes move {
-  from { transform: translateX(-10%); }
-  to   { transform: translateX(10%); }
+  background: var(--bg-color);
+  padding: var(--spacing-lg);
 }
 
 .auth-card {
-  width: 420px;
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(30px);
+  width: 100%;
+  max-width: 400px;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow);
-  padding: 3rem 2.5rem;
+  box-shadow: var(--shadow-soft);
+  padding: var(--spacing-xl) var(--spacing-lg);
   color: var(--text-color);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--spacing-lg);
+  text-align: center;
 }
 
 .auth-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-md);
 }
 
 .auth-form label {
-  display: flex;
-  flex-direction: column;
   font-size: 0.875rem;
+  text-align: left;
 }
 
 .auth-form input {
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-sm);
   border-radius: var(--radius-base);
   border: 1px solid var(--border-color);
   background: var(--surface-color);
 }
 
 .auth-form .btn-primary {
-  margin-top: 0.5rem;
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-sm);
   border-radius: var(--radius-base);
-  background: linear-gradient(120deg, var(--primary-color), var(--secondary-color));
+  background: var(--primary-color);
   color: #fff;
   font-weight: 600;
   border: none;
@@ -79,4 +62,19 @@
 .switch-link a {
   color: var(--primary-color);
   text-decoration: underline;
+}
+
+.twofa-input {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-xs);
+}
+.twofa-input input {
+  width: 40px;
+  height: 40px;
+  text-align: center;
+  font-size: 1.25rem;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
 }

--- a/src/styles/register.scss
+++ b/src/styles/register.scss
@@ -6,64 +6,47 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(120deg, var(--primary-color), var(--secondary-color));
-  padding: 2rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.auth-page::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.15), transparent 70%),
-                    radial-gradient(circle at 80% 80%, rgba(255,255,255,0.1), transparent 70%);
-  animation: move 20s linear infinite;
-}
-
-@keyframes move {
-  from { transform: translateX(-10%); }
-  to   { transform: translateX(10%); }
+  background: var(--bg-color);
+  padding: var(--spacing-lg);
 }
 
 .auth-card {
-  width: 420px;
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(30px);
+  width: 100%;
+  max-width: 400px;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow);
-  padding: 3rem 2.5rem;
+  box-shadow: var(--shadow-soft);
+  padding: var(--spacing-xl) var(--spacing-lg);
   color: var(--text-color);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--spacing-lg);
+  text-align: center;
 }
 
 .auth-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-md);
 }
 
 .auth-form label {
-  display: flex;
-  flex-direction: column;
   font-size: 0.875rem;
+  text-align: left;
 }
 
 .auth-form input {
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-sm);
   border-radius: var(--radius-base);
   border: 1px solid var(--border-color);
   background: var(--surface-color);
 }
 
 .auth-form .btn-primary {
-  margin-top: 0.5rem;
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-sm);
   border-radius: var(--radius-base);
-  background: linear-gradient(120deg, var(--primary-color), var(--secondary-color));
+  background: var(--primary-color);
   color: #fff;
   font-weight: 600;
   border: none;
@@ -79,4 +62,19 @@
 .switch-link a {
   color: var(--primary-color);
   text-decoration: underline;
+}
+
+.twofa-input {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-xs);
+}
+.twofa-input input {
+  width: 40px;
+  height: 40px;
+  text-align: center;
+  font-size: 1.25rem;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
 }


### PR DESCRIPTION
## Summary
- redesign login and register pages with minimal glass look
- add a reusable OTP input component for 2FA
- switch login and register to the new OTP input

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868456f8948832c833e266b6696ff3c