### PR TITLE
Fix landing page error

### DIFF
--- a/php/get_whop.php
+++ b/php/get_whop.php
@@ -182,7 +182,6 @@ if ($method === 'GET') {
                   w.socials,
                   w.who_for,
                   w.faq,
-                  w.landing_texts,
                   w.created_at
                 FROM whops AS w
                 JOIN users4 AS u ON w.owner_id = u.id
@@ -270,7 +269,7 @@ if ($method === 'GET') {
                     "billing_period"         => $w['billing_period'],
                     "waitlist_enabled"       => (int)$w['waitlist_enabled'],
                     "waitlist_questions"     => json_decode($w['waitlist_questions'], true) ?: [],
-                    "landing_texts"         => json_decode($w['landing_texts'], true) ?: new stdClass(),
+                    "landing_texts"         => new stdClass(),
                     "website_url"            => $w['website_url'],
                     "socials"                => json_decode($w['socials'], true) ?: new stdClass(),
                     "who_for"                => json_decode($w['who_for'], true)   ?: [],

--- a/php/whop.php
+++ b/php/whop.php
@@ -297,9 +297,6 @@ if ($method === 'GET') {
    $faq         = isset($input['faq'])
                   ? json_encode($input['faq'], JSON_UNESCAPED_UNICODE)
                   : json_encode([], JSON_UNESCAPED_UNICODE);
-    $landing_texts = isset($input['landing_texts'])
-                   ? json_encode($input['landing_texts'], JSON_UNESCAPED_UNICODE)
-                   : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
 
     // Slug uniqueness
     try {
@@ -329,12 +326,12 @@ if ($method === 'GET') {
             (owner_id, user_id, name, slug, description, logo_url, banner_url,
              price, billing_period, is_recurring, currency,
              waitlist_enabled, waitlist_questions,
-             about_bio, website_url, socials, who_for, faq, landing_texts)
+             about_bio, website_url, socials, who_for, faq)
           VALUES
             (:owner_id, :user_id, :name, :slug, :description, :logo_url, :banner_url,
              :price, :billing_period, :is_recurring, :currency,
              :wlen, :wlq,
-             :abt, :web, :soc, :who, :faq, :ltx)
+             :abt, :web, :soc, :who, :faq)
         ";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([
@@ -356,7 +353,6 @@ if ($method === 'GET') {
             'soc'            => $socials,
             'who'            => $who_for,
             'faq'            => $faq,
-            'ltx'            => $landing_texts,
         ]);
         $newId = (int)$pdo->lastInsertId();
 


### PR DESCRIPTION
## Summary
- fix `get_whop.php` query to omit missing `landing_texts` column and return default
- remove `landing_texts` column usage from `whop.php` insert query

## Testing
- `npm install`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6868518273a8832ca6ed47adc173df26