### PR TITLE
Fix setup data & review auth

### DIFF
--- a/php/whop.php
+++ b/php/whop.php
@@ -290,16 +290,19 @@ if ($method === 'GET') {
                         : json_encode([], JSON_UNESCAPED_UNICODE);
     $about_bio   = trim($input['about_bio']   ?? "");
     $long_desc   = trim($input['long_description'] ?? "");
-    $website_url = trim($input['website_url'] ?? "");
-    $socials     = isset($input['socials'])
-                   ? json_encode($input['socials'], JSON_UNESCAPED_UNICODE)
-                   : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
-    $who_for     = isset($input['who_for'])
-                   ? json_encode($input['who_for'], JSON_UNESCAPED_UNICODE)
-                   : json_encode([], JSON_UNESCAPED_UNICODE);
+   $website_url = trim($input['website_url'] ?? "");
+   $socials     = isset($input['socials'])
+                  ? json_encode($input['socials'], JSON_UNESCAPED_UNICODE)
+                  : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
+   $who_for     = isset($input['who_for'])
+                  ? json_encode($input['who_for'], JSON_UNESCAPED_UNICODE)
+                  : json_encode([], JSON_UNESCAPED_UNICODE);
    $faq         = isset($input['faq'])
                   ? json_encode($input['faq'], JSON_UNESCAPED_UNICODE)
                   : json_encode([], JSON_UNESCAPED_UNICODE);
+   $landing_texts = isset($input['landing_texts'])
+                   ? json_encode($input['landing_texts'], JSON_UNESCAPED_UNICODE)
+                   : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
 
     // Slug uniqueness
     try {
@@ -329,12 +332,12 @@ if ($method === 'GET') {
             (owner_id, user_id, name, slug, description, long_description, logo_url, banner_url,
              price, billing_period, is_recurring, currency,
              waitlist_enabled, waitlist_questions,
-             about_bio, website_url, socials, who_for, faq)
+             about_bio, website_url, socials, who_for, faq, landing_texts)
           VALUES
             (:owner_id, :user_id, :name, :slug, :description, :long_desc, :logo_url, :banner_url,
              :price, :billing_period, :is_recurring, :currency,
              :wlen, :wlq,
-             :abt, :web, :soc, :who, :faq)
+             :abt, :web, :soc, :who, :faq, :land)
         ";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([
@@ -357,6 +360,7 @@ if ($method === 'GET') {
             'soc'            => $socials,
             'who'            => $who_for,
             'faq'            => $faq,
+            'land'           => $landing_texts,
         ]);
         $newId = (int)$pdo->lastInsertId();
 

--- a/src/pages/WhopDashboard/components/LandingPage.jsx
+++ b/src/pages/WhopDashboard/components/LandingPage.jsx
@@ -206,6 +206,7 @@ export default function LandingPage({
               const res = await fetch("https://app.byxbot.com/php/add_review.php", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
+                credentials: "include",
                 body: JSON.stringify(payload),
               });
               const j = await res.json();

--- a/src/styles/whop-dashboard/landing-page.scss
+++ b/src/styles/whop-dashboard/landing-page.scss
@@ -4,6 +4,10 @@
   opacity: 0;
   transition: opacity 0.6s ease-in;
 }
+.landing-page {
+  font-family: var(--font-family);
+  color: var(--text-color);
+}
 .landing-page.loaded,
 .lp-root.loaded {
   opacity: 1;
@@ -29,7 +33,9 @@
   color: #fff;
 }
 .hero-overlay {
-  position: absolute; inset: 0; background: rgba(0,0,0,0.5);
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.3));
 }
 .hero-content {
   position: relative; z-index: 1; max-width: 700px; padding: 20px;
@@ -90,6 +96,10 @@
 .section,
 .lp-section {
   padding: 60px 20px; text-align: center;
+}
+.section-title {
+  font-size: 2rem;
+  margin-bottom: 20px;
 }
 .alt {
   background: #f0f0f0;


### PR DESCRIPTION
## Summary
- ensure review submission sends credentials
- store landing page text data when creating a whop
- style improvements for landing pages

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68685e39e4c0832ca5b94cc8c6f4a71b