### PR TITLE
Enable past member reviews and preserve setup data

### DIFF
--- a/php/add_review.php
+++ b/php/add_review.php
@@ -48,6 +48,11 @@ try {
         $purchase = $st2->fetchColumn();
     }
     if (!$purchase) {
+        $st3 = $pdo->prepare("SELECT payment_date FROM payments WHERE user_id = :uid AND whop_id = :wid ORDER BY payment_date ASC LIMIT 1");
+        $st3->execute(['uid' => $user_id, 'wid' => $whop_id]);
+        $purchase = $st3->fetchColumn();
+    }
+    if (!$purchase) {
         http_response_code(403);
         echo json_encode(["status" => "error", "message" => "You must be a member to review."]);
         exit;

--- a/src/components/ReviewSection.jsx
+++ b/src/components/ReviewSection.jsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from "react";
+import { FaStar } from "react-icons/fa";
+import "../styles/whop-dashboard/landing-page.scss";
+import { useNotifications } from "./NotificationProvider";
+
+export default function ReviewSection({ whopId, title }) {
+  const { showNotification } = useNotifications();
+  const [reviews, setReviews] = useState([]);
+  const [newReview, setNewReview] = useState({ text: "", rating: 5 });
+
+  useEffect(() => {
+    if (!whopId) return;
+    fetch(`https://app.byxbot.com/php/get_reviews.php?whop_id=${whopId}`,
+      { credentials: "include" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (j.status === "success") setReviews(j.data);
+      })
+      .catch(() => {});
+  }, [whopId]);
+
+  async function handleDelete(id) {
+    await fetch("https://app.byxbot.com/php/delete_review.php", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ review_id: id }),
+      credentials: "include",
+    });
+    const fr = await fetch(`https://app.byxbot.com/php/get_reviews.php?whop_id=${whopId}`,
+      { credentials: "include" });
+    const jj = await fr.json();
+    if (jj.status === "success") setReviews(jj.data);
+  }
+
+  async function handleSubmit() {
+    const payload = { ...newReview, whop_id: whopId };
+    const res = await fetch("https://app.byxbot.com/php/add_review.php", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    });
+    const j = await res.json();
+    if (j.status === "success") {
+      setNewReview({ text: "", rating: 5 });
+      const fr = await fetch(`https://app.byxbot.com/php/get_reviews.php?whop_id=${whopId}`,
+        { credentials: "include" });
+      const jj = await fr.json();
+      if (jj.status === "success") setReviews(jj.data);
+    } else {
+      showNotification({ type: "error", message: j.message || "Error" });
+    }
+  }
+
+  return (
+    <section className="section reviews-section">
+      <h2 className="section-title">{title}</h2>
+      <div className="reviews-grid">
+        {reviews.map((r) => (
+          <div key={r.id} className="card review glass">
+            <div className="review-rating">
+              {Array.from({ length: r.rating }).map((_, j) => (
+                <FaStar key={j} />
+              ))}
+            </div>
+            <p className="review-text">“{r.text}”</p>
+            <div className="review-meta">
+              <span className="review-author">
+                <img src={r.avatar_url} alt="avatar" className="review-avatar" /> {r.username}
+              </span>
+              <span className="review-date">
+                Bought {new Date(r.purchase_at).toLocaleDateString()}
+              </span>
+            </div>
+            {r.is_mine === 1 && (
+              <button className="btn outline" onClick={() => handleDelete(r.id)}>
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="review-form">
+        <div className="rating-select">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <FaStar
+              key={i}
+              onClick={() => setNewReview({ ...newReview, rating: i + 1 })}
+              className={i < newReview.rating ? "active" : ""}
+            />
+          ))}
+        </div>
+        <textarea
+          className="review-input"
+          placeholder="Your review"
+          value={newReview.text}
+          onChange={(e) => setNewReview({ ...newReview, text: e.target.value })}
+        />
+        <button className="btn primary" onClick={handleSubmit}>
+          Submit Review
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ChooseLink.jsx
+++ b/src/pages/ChooseLink.jsx
@@ -56,15 +56,8 @@ export default function ChooseLink() {
     if (!slug.trim()) return;
 
     const whopData = {
-      name: prevWhopData.name,
-      description: prevWhopData.description,
+      ...prevWhopData,
       slug: slug.trim(),
-      features: prevWhopData.features || [],
-      logoUrl: prevWhopData.logoUrl || "",
-      price: prevWhopData.price || 0.0,
-      billing_period: prevWhopData.billing_period || "none",
-      is_recurring: prevWhopData.is_recurring || 0,
-      currency: prevWhopData.currency || "USD",
     };
 
     setWhopSetupCookie(whopData);

--- a/src/pages/FeaturesSetup.jsx
+++ b/src/pages/FeaturesSetup.jsx
@@ -193,19 +193,12 @@ export default function FeaturesSetup() {
     if (!isContinueEnabled) return;
 
     const whopData = {
-      name: prevWhopData.name,
-      description: prevWhopData.description,
-      slug: prevWhopData.slug,
+      ...prevWhopData,
       features: features.map((f) => ({
         title: f.title.trim(),
         subtitle: f.subtitle.trim(),
         imageUrl: f.imageUrl,
       })),
-      logoUrl: prevWhopData.logoUrl || "",
-      price: prevWhopData.price || 0.0,
-      billing_period: prevWhopData.billing_period || "none",
-      is_recurring: prevWhopData.is_recurring || 0,
-      currency: prevWhopData.currency || "USD",
     };
 
     setWhopSetupCookie(whopData);

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -3,6 +3,7 @@
 import React from "react";
 import "../../../styles/whop-dashboard/_member.scss";
 import ChatWindow from "../../../components/Chat/ChatWindow";
+import ReviewSection from "../../../components/ReviewSection";
 
 export default function MemberMain({
   whopData,
@@ -39,6 +40,10 @@ export default function MemberMain({
               </div>
             ))}
           </div>
+          <ReviewSection
+            whopId={whopData.id}
+            title={whopData.landing_texts?.reviews_title || "See what other people are saying"}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- allow review submission if a past payment exists
- keep all setup fields when moving through setup wizard
- add reusable `ReviewSection` component
- show reviews in member view

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fa4df6c4832cbf265ce4e8426fb7