### PR TITLE
Fix missing landing_texts column

### DIFF
--- a/php/get_whop.php
+++ b/php/get_whop.php
@@ -183,6 +183,7 @@ if ($method === 'GET') {
                   w.socials,
                   w.who_for,
                   w.faq,
+                  w.landing_texts,
                   w.created_at
                 FROM whops AS w
                 JOIN users4 AS u ON w.owner_id = u.id
@@ -271,7 +272,7 @@ if ($method === 'GET') {
                     "billing_period"         => $w['billing_period'],
                     "waitlist_enabled"       => (int)$w['waitlist_enabled'],
                     "waitlist_questions"     => json_decode($w['waitlist_questions'], true) ?: [],
-                    "landing_texts"         => new stdClass(),
+                    "landing_texts"         => json_decode($w['landing_texts'], true) ?: new stdClass(),
                     "website_url"            => $w['website_url'],
                     "socials"                => json_decode($w['socials'], true) ?: new stdClass(),
                     "who_for"                => json_decode($w['who_for'], true)   ?: [],

--- a/sql/update_whops_add_landing_texts.sql
+++ b/sql/update_whops_add_landing_texts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE whops
+  ADD COLUMN landing_texts TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary
- add migration script to add `landing_texts` column to `whops`
- return landing text data in `get_whop.php`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690b3aa1e8832ca4ca36657d07d1eb