### PR TITLE
Add editable owner texts

### DIFF
--- a/php/update_whop.php
+++ b/php/update_whop.php
@@ -144,11 +144,18 @@ $wait_enabled   = isset($data['waitlist_enabled']) ? intval($data['waitlist_enab
 $wait_questions = $wait_enabled && isset($data['waitlist_questions']) && is_array($data['waitlist_questions'])
     ? json_encode(array_values(array_filter($data['waitlist_questions'], fn($q)=>trim($q)!=='')))
     : json_encode([]);
+$long_desc      = trim($data['long_description'] ?? '');
+$about_bio      = trim($data['about_bio'] ?? '');
+$website_url    = trim($data['website_url'] ?? '');
+$socials_json   = isset($data['socials']) ? json_encode($data['socials'], JSON_UNESCAPED_UNICODE) : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
+$who_for_json   = isset($data['who_for']) ? json_encode($data['who_for'], JSON_UNESCAPED_UNICODE) : json_encode([], JSON_UNESCAPED_UNICODE);
+$faq_json       = isset($data['faq']) ? json_encode($data['faq'], JSON_UNESCAPED_UNICODE) : json_encode([], JSON_UNESCAPED_UNICODE);
+$landing_json   = isset($data['landing_texts']) ? json_encode($data['landing_texts'], JSON_UNESCAPED_UNICODE) : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
 
 // 12) Update the Whop record
 try {
     $updStmt = $pdo->prepare("
-        UPDATE whops 
+        UPDATE whops
            SET name               = :name,
                description        = :description,
                banner_url         = :banner_url,
@@ -157,8 +164,15 @@ try {
                is_recurring       = :is_recurring,
                billing_period     = :billing_period,
                waitlist_enabled   = :wait_enabled,
-               waitlist_questions = :wait_questions
-         WHERE id = :id
+               waitlist_questions = :wait_questions,
+               long_description   = :long_desc,
+               about_bio          = :about_bio,
+               website_url        = :website_url,
+               socials            = :socials,
+               who_for            = :who_for,
+               faq                = :faq,
+               landing_texts      = :landing_texts
+        WHERE id = :id
     ");
     $updStmt->execute([
         ':name'             => $data['name'],
@@ -170,6 +184,13 @@ try {
         ':billing_period'   => $billing_period,
         ':wait_enabled'     => $wait_enabled,
         ':wait_questions'   => $wait_questions,
+        ':long_desc'        => $long_desc,
+        ':about_bio'        => $about_bio,
+        ':website_url'      => $website_url,
+        ':socials'          => $socials_json,
+        ':who_for'          => $who_for_json,
+        ':faq'              => $faq_json,
+        ':landing_texts'    => $landing_json,
         ':id'               => $whopId
     ]);
 } catch (PDOException $e) {

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -65,6 +65,20 @@ export default function WhopDashboard() {
   // Feature-edit
   const [editFeatures, setEditFeatures] = useState([]);
 
+  // Text-edit states
+  const [editLongDescription, setEditLongDescription] = useState("");
+  const [editAboutBio, setEditAboutBio] = useState("");
+  const [editWebsiteUrl, setEditWebsiteUrl] = useState("");
+  const [editSocials, setEditSocials] = useState({ instagram: "", discord: "" });
+  const [editWhoFor, setEditWhoFor] = useState([{ title: "", description: "" }]);
+  const [editFaq, setEditFaq] = useState([{ question: "", answer: "" }]);
+  const [editLandingTexts, setEditLandingTexts] = useState({
+    reviews_title: "",
+    features_title: "",
+    about_title: "",
+    faq_title: "",
+  });
+
   // Waitlist
   const [waitlistEnabled, setWaitlistEnabled] = useState(false);
   const [waitlistQuestions, setWaitlistQuestions] = useState(["", "", "", "", ""]);
@@ -104,7 +118,14 @@ export default function WhopDashboard() {
       setEditFeatures,
       fetchCampaignsBound,
       setWaitlistEnabled,
-      setWaitlistQuestions
+      setWaitlistQuestions,
+      setEditLongDescription,
+      setEditAboutBio,
+      setEditWebsiteUrl,
+      setEditSocials,
+      setEditWhoFor,
+      setEditFaq,
+      setEditLandingTexts
     );
   }, [initialSlug, location.pathname]);
 
@@ -212,8 +233,22 @@ export default function WhopDashboard() {
       setSlugError,
       fetchCampaignsBound,
       setWhopData,
+      setEditLongDescription,
+      setEditAboutBio,
+      setEditWebsiteUrl,
+      setEditSocials,
+      setEditWhoFor,
+      setEditFaq,
+      setEditLandingTexts,
       waitlistEnabled,
-      waitlistQuestions
+      waitlistQuestions,
+      editLongDescription,
+      editAboutBio,
+      editWebsiteUrl,
+      editSocials,
+      editWhoFor,
+      editFaq,
+      editLandingTexts
     );
   };
 
@@ -263,7 +298,14 @@ export default function WhopDashboard() {
         setEditFeatures,
         fetchCampaignsBound,
         setWaitlistEnabled,
-        setWaitlistQuestions
+        setWaitlistQuestions,
+        setEditLongDescription,
+        setEditAboutBio,
+        setEditWebsiteUrl,
+        setEditSocials,
+        setEditWhoFor,
+        setEditFaq,
+        setEditLandingTexts
       );
     } catch {
       // handleRequestWaitlist throws errors for conflict or server error
@@ -385,6 +427,20 @@ export default function WhopDashboard() {
       setWaitlistEnabled={setWaitlistEnabled}
       waitlistQuestions={waitlistQuestions}
       setWaitlistQuestions={setWaitlistQuestions}
+      editLongDescription={editLongDescription}
+      setEditLongDescription={setEditLongDescription}
+      editAboutBio={editAboutBio}
+      setEditAboutBio={setEditAboutBio}
+      editWebsiteUrl={editWebsiteUrl}
+      setEditWebsiteUrl={setEditWebsiteUrl}
+      editSocials={editSocials}
+      setEditSocials={setEditSocials}
+      editWhoFor={editWhoFor}
+      setEditWhoFor={setEditWhoFor}
+      editFaq={editFaq}
+      setEditFaq={setEditFaq}
+      editLandingTexts={editLandingTexts}
+      setEditLandingTexts={setEditLandingTexts}
     />
   );
 }

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -11,6 +11,7 @@ import FeaturesSection from "./FeaturesSection";
 import CampaignsSection from "./CampaignsSection";
 import MembersSection from "./MembersSection";
 import CampaignModal from "./CampaignModal";
+import OwnerTextMenu from "./OwnerTextMenu";
 
 export default function OwnerMode({
   whopData,
@@ -51,6 +52,20 @@ export default function OwnerMode({
   handleBack,
   isCampaignModalOpen,
   fetchCampaigns,
+  editLongDescription,
+  setEditLongDescription,
+  editAboutBio,
+  setEditAboutBio,
+  editWebsiteUrl,
+  setEditWebsiteUrl,
+  editSocials,
+  setEditSocials,
+  editWhoFor,
+  setEditWhoFor,
+  editFaq,
+  setEditFaq,
+  editLandingTexts,
+  setEditLandingTexts,
 }) {
   if (!whopData) return null;
 
@@ -80,6 +95,25 @@ export default function OwnerMode({
         bannerError={bannerError}
         handleBannerUpload={handleBannerUpload}
       />
+
+      {isEditing && (
+        <OwnerTextMenu
+          editLongDescription={editLongDescription}
+          setEditLongDescription={setEditLongDescription}
+          editAboutBio={editAboutBio}
+          setEditAboutBio={setEditAboutBio}
+          editWebsiteUrl={editWebsiteUrl}
+          setEditWebsiteUrl={setEditWebsiteUrl}
+          editSocials={editSocials}
+          setEditSocials={setEditSocials}
+          editWhoFor={editWhoFor}
+          setEditWhoFor={setEditWhoFor}
+          editFaq={editFaq}
+          setEditFaq={setEditFaq}
+          editLandingTexts={editLandingTexts}
+          setEditLandingTexts={setEditLandingTexts}
+        />
+      )}
 
       <div className="whop-content">
         {/* Slug and price editing section */}

--- a/src/pages/WhopDashboard/components/OwnerTextMenu.jsx
+++ b/src/pages/WhopDashboard/components/OwnerTextMenu.jsx
@@ -1,0 +1,177 @@
+import React from "react";
+import "../../../styles/whop-dashboard/_owner.scss";
+
+export default function OwnerTextMenu({
+  editLongDescription,
+  setEditLongDescription,
+  editAboutBio,
+  setEditAboutBio,
+  editWebsiteUrl,
+  setEditWebsiteUrl,
+  editSocials,
+  setEditSocials,
+  editWhoFor,
+  setEditWhoFor,
+  editFaq,
+  setEditFaq,
+  editLandingTexts,
+  setEditLandingTexts,
+}) {
+  const handleSocialChange = (key, value) => {
+    setEditSocials((prev) => ({ ...prev, [key]: value }));
+  };
+  const addWhoFor = () =>
+    setEditWhoFor((prev) => [...prev, { title: "", description: "" }]);
+  const removeWhoFor = (i) => {
+    if (editWhoFor.length <= 1) return;
+    setEditWhoFor((prev) => prev.filter((_, idx) => idx !== i));
+  };
+  const handleWhoForChange = (i, field, v) => {
+    setEditWhoFor((prev) =>
+      prev.map((item, idx) => (idx === i ? { ...item, [field]: v } : item))
+    );
+  };
+  const addFaq = () => setEditFaq((prev) => [...prev, { question: "", answer: "" }]);
+  const removeFaq = (i) => {
+    if (editFaq.length <= 1) return;
+    setEditFaq((prev) => prev.filter((_, idx) => idx !== i));
+  };
+  const handleFaqChange = (i, field, v) => {
+    setEditFaq((prev) =>
+      prev.map((item, idx) => (idx === i ? { ...item, [field]: v } : item))
+    );
+  };
+  const handleLandingTextChange = (field, value) => {
+    setEditLandingTexts((prev) => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <div className="owner-text-menu">
+      <h3>Edit Text Content</h3>
+      <textarea
+        className="otm-textarea"
+        placeholder="Long description"
+        value={editLongDescription}
+        onChange={(e) => setEditLongDescription(e.target.value)}
+        rows={3}
+      />
+      <textarea
+        className="otm-textarea"
+        placeholder="About bio"
+        value={editAboutBio}
+        onChange={(e) => setEditAboutBio(e.target.value)}
+        rows={3}
+      />
+      <input
+        type="text"
+        className="otm-input"
+        placeholder="Website URL"
+        value={editWebsiteUrl}
+        onChange={(e) => setEditWebsiteUrl(e.target.value)}
+      />
+      <input
+        type="text"
+        className="otm-input"
+        placeholder="Instagram URL"
+        value={editSocials.instagram}
+        onChange={(e) => handleSocialChange("instagram", e.target.value)}
+      />
+      <input
+        type="text"
+        className="otm-input"
+        placeholder="Discord URL"
+        value={editSocials.discord}
+        onChange={(e) => handleSocialChange("discord", e.target.value)}
+      />
+      <div className="otm-section">
+        <h4>Who this is for</h4>
+        {editWhoFor.map((item, i) => (
+          <div key={i} className="otm-subgroup">
+            <input
+              type="text"
+              className="otm-input"
+              placeholder="Title"
+              value={item.title}
+              onChange={(e) => handleWhoForChange(i, "title", e.target.value)}
+            />
+            <textarea
+              className="otm-textarea"
+              placeholder="Description"
+              value={item.description}
+              onChange={(e) => handleWhoForChange(i, "description", e.target.value)}
+              rows={2}
+            />
+            {editWhoFor.length > 1 && (
+              <button className="otm-remove" onClick={() => removeWhoFor(i)}>
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+        <button className="otm-add" onClick={addWhoFor}>
+          + Add
+        </button>
+      </div>
+      <div className="otm-section">
+        <h4>FAQ</h4>
+        {editFaq.map((item, i) => (
+          <div key={i} className="otm-subgroup">
+            <input
+              type="text"
+              className="otm-input"
+              placeholder="Question"
+              value={item.question}
+              onChange={(e) => handleFaqChange(i, "question", e.target.value)}
+            />
+            <textarea
+              className="otm-textarea"
+              placeholder="Answer"
+              value={item.answer}
+              onChange={(e) => handleFaqChange(i, "answer", e.target.value)}
+              rows={2}
+            />
+            {editFaq.length > 1 && (
+              <button className="otm-remove" onClick={() => removeFaq(i)}>
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+        <button className="otm-add" onClick={addFaq}>
+          + Add FAQ
+        </button>
+      </div>
+      <div className="otm-section">
+        <h4>Section Titles</h4>
+        <input
+          type="text"
+          className="otm-input"
+          placeholder="Reviews title"
+          value={editLandingTexts.reviews_title || ""}
+          onChange={(e) => handleLandingTextChange("reviews_title", e.target.value)}
+        />
+        <input
+          type="text"
+          className="otm-input"
+          placeholder="Features title"
+          value={editLandingTexts.features_title || ""}
+          onChange={(e) => handleLandingTextChange("features_title", e.target.value)}
+        />
+        <input
+          type="text"
+          className="otm-input"
+          placeholder="About title"
+          value={editLandingTexts.about_title || ""}
+          onChange={(e) => handleLandingTextChange("about_title", e.target.value)}
+        />
+        <input
+          type="text"
+          className="otm-input"
+          placeholder="FAQ title"
+          value={editLandingTexts.faq_title || ""}
+          onChange={(e) => handleLandingTextChange("faq_title", e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -12,7 +12,14 @@ export default async function fetchWhopData(
   setEditFeatures,
   fetchCampaigns,        // bound version
   setWaitlistEnabled,    // newly added
-  setWaitlistQuestions   // newly added
+  setWaitlistQuestions,  // newly added
+  setEditLongDescription,
+  setEditAboutBio,
+  setEditWebsiteUrl,
+  setEditSocials,
+  setEditWhoFor,
+  setEditFaq,
+  setEditLandingTexts
 ) {
   setLoading(true);
   setError("");
@@ -57,6 +64,30 @@ export default async function fetchWhopData(
           error: "",
         }))
       );
+
+      setEditLongDescription(data.long_description || "");
+      setEditAboutBio(data.about_bio || "");
+      setEditWebsiteUrl(data.website_url || "");
+      setEditSocials({
+        instagram: data.socials?.instagram || "",
+        discord: data.socials?.discord || "",
+      });
+      setEditWhoFor(
+        Array.isArray(data.who_for) && data.who_for.length
+          ? data.who_for
+          : [{ title: "", description: "" }]
+      );
+      setEditFaq(
+        Array.isArray(data.faq) && data.faq.length
+          ? data.faq
+          : [{ question: "", answer: "" }]
+      );
+      setEditLandingTexts(data.landing_texts || {
+        reviews_title: "",
+        features_title: "",
+        about_title: "",
+        faq_title: "",
+      });
 
       // ** Waitlist state **
       setWaitlistEnabled(Boolean(data.waitlist_enabled));

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -15,8 +15,22 @@ export default async function handleSaveWhop(
   setSlugError,
   fetchCampaigns,
   setWhopData,
+  setEditLongDescription,
+  setEditAboutBio,
+  setEditWebsiteUrl,
+  setEditSocials,
+  setEditWhoFor,
+  setEditFaq,
+  setEditLandingTexts,
   waitlistEnabled,         // new parameter
-  waitlistQuestions        // new parameter
+  waitlistQuestions,       // new parameter
+  editLongDescription,
+  editAboutBio,
+  editWebsiteUrl,
+  editSocials,
+  editWhoFor,
+  editFaq,
+  editLandingTexts
 ) {
   // 1) Validate name and description
   if (!editName.trim() || !editDescription.trim()) {
@@ -50,6 +64,13 @@ export default async function handleSaveWhop(
     waitlist_questions: waitlistEnabled
                            ? waitlistQuestions.filter(q => q.trim() !== "")
                            : [],
+    long_description:   editLongDescription.trim(),
+    about_bio:          editAboutBio.trim(),
+    website_url:        editWebsiteUrl.trim(),
+    socials:            editSocials,
+    who_for:            editWhoFor,
+    faq:                editFaq,
+    landing_texts:      editLandingTexts,
   };
 
   try {
@@ -97,6 +118,30 @@ export default async function handleSaveWhop(
       setEditName(data.name);
       setEditDescription(data.description);
       setEditBannerUrl(data.banner_url || "");
+
+      setEditLongDescription(data.long_description || "");
+      setEditAboutBio(data.about_bio || "");
+      setEditWebsiteUrl(data.website_url || "");
+      setEditSocials({
+        instagram: data.socials?.instagram || "",
+        discord: data.socials?.discord || "",
+      });
+      setEditWhoFor(
+        Array.isArray(data.who_for) && data.who_for.length
+          ? data.who_for
+          : [{ title: "", description: "" }]
+      );
+      setEditFaq(
+        Array.isArray(data.faq) && data.faq.length
+          ? data.faq
+          : [{ question: "", answer: "" }]
+      );
+      setEditLandingTexts(data.landing_texts || {
+        reviews_title: "",
+        features_title: "",
+        about_title: "",
+        faq_title: "",
+      });
 
       // Rebuild features state
       const newFeatures = data.features.map((f, idx) => ({

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -716,7 +716,71 @@
     position: relative;
     flex-direction: column;
   }
-  .member-main {
+.member-main {
     margin-top: var(--spacing-lg);
+  }
+}
+
+.owner-text-menu {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 18rem;
+  height: 100%;
+  background: var(--surface-color);
+  border-left: 1px solid var(--border-color);
+  padding: var(--spacing-md);
+  overflow-y: auto;
+  box-shadow: var(--shadow-soft);
+  z-index: 1000;
+
+  h3,
+  h4 {
+    color: var(--text-color);
+    margin-top: var(--spacing-sm);
+    margin-bottom: var(--spacing-sm);
+    text-align: center;
+  }
+
+  .otm-input,
+  .otm-textarea {
+    width: 100%;
+    padding: var(--spacing-xs);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-base);
+    background: var(--surface-color);
+    color: var(--text-color);
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .otm-subgroup {
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .otm-remove,
+  .otm-add {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    background: var(--primary-color);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: 0.8rem;
+    cursor: pointer;
+    box-shadow: var(--shadow-soft);
+    transition: background var(--transition), transform var(--transition);
+    margin-top: var(--spacing-xs);
+  }
+
+  .otm-remove {
+    background: var(--error-color);
+  }
+
+  .otm-remove:hover,
+  .otm-add:hover {
+    background: var(--primary-hover);
+    transform: translateY(-1px);
   }
 }


### PR DESCRIPTION
## Summary
- allow owners to modify long descriptions, about bio, FAQs and more
- add OwnerTextMenu side panel component
- extend whop update logic and API fields
- style new owner text menu

## Testing
- `npm test --silent -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690de41d84832cafbdfd8431dea985