### PR TITLE
Add modular feature toggles

### DIFF
--- a/php/get_whop.php
+++ b/php/get_whop.php
@@ -184,6 +184,7 @@ if ($method === 'GET') {
                   w.who_for,
                   w.faq,
                   w.landing_texts,
+                  w.modules,
                   w.created_at
                 FROM whops AS w
                 JOIN users4 AS u ON w.owner_id = u.id
@@ -273,6 +274,7 @@ if ($method === 'GET') {
                     "waitlist_enabled"       => (int)$w['waitlist_enabled'],
                     "waitlist_questions"     => json_decode($w['waitlist_questions'], true) ?: [],
                     "landing_texts"         => json_decode($w['landing_texts'], true) ?: new stdClass(),
+                    "modules"               => json_decode($w['modules'], true) ?: new stdClass(),
                     "website_url"            => $w['website_url'],
                     "socials"                => json_decode($w['socials'], true) ?: new stdClass(),
                     "who_for"                => json_decode($w['who_for'], true)   ?: [],
@@ -310,6 +312,7 @@ if ($method === 'GET') {
                     logo_url, banner_url,
                     price, currency,
                     is_recurring, billing_period,
+                    modules,
                     created_at
                 FROM whops
                 WHERE owner_id = :uid

--- a/php/update_whop.php
+++ b/php/update_whop.php
@@ -151,6 +151,7 @@ $socials_json   = isset($data['socials']) ? json_encode($data['socials'], JSON_U
 $who_for_json   = isset($data['who_for']) ? json_encode($data['who_for'], JSON_UNESCAPED_UNICODE) : json_encode([], JSON_UNESCAPED_UNICODE);
 $faq_json       = isset($data['faq']) ? json_encode($data['faq'], JSON_UNESCAPED_UNICODE) : json_encode([], JSON_UNESCAPED_UNICODE);
 $landing_json   = isset($data['landing_texts']) ? json_encode($data['landing_texts'], JSON_UNESCAPED_UNICODE) : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
+$modules_json   = isset($data['modules']) ? json_encode($data['modules'], JSON_UNESCAPED_UNICODE) : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
 
 // 12) Update the Whop record
 try {
@@ -171,7 +172,8 @@ try {
                socials            = :socials,
                who_for            = :who_for,
                faq                = :faq,
-               landing_texts      = :landing_texts
+               landing_texts      = :landing_texts,
+               modules            = :modules
         WHERE id = :id
     ");
     $updStmt->execute([
@@ -191,6 +193,7 @@ try {
         ':who_for'          => $who_for_json,
         ':faq'              => $faq_json,
         ':landing_texts'    => $landing_json,
+        ':modules'          => $modules_json,
         ':id'               => $whopId
     ]);
 } catch (PDOException $e) {

--- a/php/whop.php
+++ b/php/whop.php
@@ -303,6 +303,9 @@ if ($method === 'GET') {
    $landing_texts = isset($input['landing_texts'])
                    ? json_encode($input['landing_texts'], JSON_UNESCAPED_UNICODE)
                    : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
+   $modules_json = isset($input['modules'])
+                   ? json_encode($input['modules'], JSON_UNESCAPED_UNICODE)
+                   : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
 
     // Slug uniqueness
     try {
@@ -332,12 +335,12 @@ if ($method === 'GET') {
             (owner_id, user_id, name, slug, description, long_description, logo_url, banner_url,
              price, billing_period, is_recurring, currency,
              waitlist_enabled, waitlist_questions,
-             about_bio, website_url, socials, who_for, faq, landing_texts)
+             about_bio, website_url, socials, who_for, faq, landing_texts, modules)
           VALUES
             (:owner_id, :user_id, :name, :slug, :description, :long_desc, :logo_url, :banner_url,
              :price, :billing_period, :is_recurring, :currency,
              :wlen, :wlq,
-             :abt, :web, :soc, :who, :faq, :land)
+             :abt, :web, :soc, :who, :faq, :land, :modules)
         ";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([
@@ -361,6 +364,7 @@ if ($method === 'GET') {
             'who'            => $who_for,
             'faq'            => $faq,
             'land'           => $landing_texts,
+            'modules'        => $modules_json,
         ]);
         $newId = (int)$pdo->lastInsertId();
 

--- a/sql/update_whops_add_modules.sql
+++ b/sql/update_whops_add_modules.sql
@@ -1,0 +1,2 @@
+ALTER TABLE whops
+  ADD COLUMN modules TEXT DEFAULT NULL;

--- a/src/pages/BannerSetup.jsx
+++ b/src/pages/BannerSetup.jsx
@@ -140,6 +140,7 @@ export default function BannerSetup() {
       waitlist_enabled: prevWhopData.waitlist_enabled || 0,
       waitlist_questions: prevWhopData.waitlist_questions || [],
       landing_texts: prevWhopData.landing_texts || {},
+      modules: prevWhopData.modules || {},
     };
 
     try {

--- a/src/pages/FeaturesSetup.jsx
+++ b/src/pages/FeaturesSetup.jsx
@@ -12,6 +12,7 @@ export default function FeaturesSetup() {
   const cookieData = getWhopSetupCookie();
   // We may get whopData either from location.state or from cookie
   const prevWhopData = location.state?.whopData || cookieData || null;
+  const textEnabled = prevWhopData?.modules?.text !== false;
 
   // Function returning initial features array state
   const getInitialFeatures = () => {
@@ -59,6 +60,22 @@ export default function FeaturesSetup() {
       <div className="features-setup-error">
         <p>Whop data not found. Please complete the previous steps first.</p>
         <button onClick={() => navigate("/setup")}>Go to Setup</button>
+      </div>
+    );
+  }
+
+  if (!textEnabled) {
+    const handleContinue = () => {
+      const newData = { ...prevWhopData };
+      setWhopSetupCookie(newData);
+      navigate("/setup/banner", { state: { whopData: newData } });
+    };
+    return (
+      <div className="features-setup-disabled">
+        <p>Text features are disabled. You can enable them in setup later.</p>
+        <button className="feature-add-btn" onClick={handleContinue}>
+          Continue
+        </button>
       </div>
     );
   }

--- a/src/pages/Setup.jsx
+++ b/src/pages/Setup.jsx
@@ -50,6 +50,15 @@ export default function Setup() {
       ? cookieData.faq
       : [{ question: "", answer: "" }]
   );
+  const [modules, setModules] = useState(
+    cookieData.modules || {
+      chat: false,
+      earn: false,
+      discord: false,
+      course: false,
+      text: true,
+    }
+  );
   const [landingTexts, setLandingTexts] = useState(
     cookieData.landing_texts || {
       reviews_title: "See what other people are saying",
@@ -86,6 +95,7 @@ export default function Setup() {
       who_for: whoFor,
       faq,
       landing_texts: landingTexts,
+      modules,
     });
   }, [
     whopName,
@@ -103,6 +113,7 @@ export default function Setup() {
     whoFor,
     faq,
     landingTexts,
+    modules,
   ]);
 
   // Handlers
@@ -134,6 +145,9 @@ export default function Setup() {
     const arr = [...waitlistQuestions];
     arr[i] = v;
     setWaitlistQuestions(arr);
+  };
+  const handleModuleToggle = (key) => {
+    setModules((prev) => ({ ...prev, [key]: !prev[key] }));
   };
   const handleBioChange = (e) => setAboutBio(e.target.value);
   const handleWebsiteChange = (e) => setWebsiteUrl(e.target.value);
@@ -343,6 +357,27 @@ export default function Setup() {
             value={socials.discord}
             onChange={(e) => handleSocialChange("discord", e.target.value)}
           />
+        </div>
+
+        {/* Modules */}
+        <div className="setup-section">
+          <h2>Enable Modules</h2>
+          {[
+            ["chat", "Chat"],
+            ["earn", "Earn"],
+            ["discord", "Discord Access"],
+            ["course", "Course"],
+            ["text", "Text Features"],
+          ].map(([key, label]) => (
+            <label key={key} className="setup-checkbox-label">
+              <input
+                type="checkbox"
+                checked={modules[key]}
+                onChange={() => handleModuleToggle(key)}
+              />
+              {` Enable ${label}`}
+            </label>
+          ))}
         </div>
 
         {/* Who This Is For */}

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -64,6 +64,13 @@ export default function WhopDashboard() {
 
   // Feature-edit
   const [editFeatures, setEditFeatures] = useState([]);
+  const [editModules, setEditModules] = useState({
+    chat: false,
+    earn: false,
+    discord: false,
+    course: false,
+    text: true,
+  });
 
   // Text-edit states
   const [editLongDescription, setEditLongDescription] = useState("");
@@ -125,7 +132,8 @@ export default function WhopDashboard() {
       setEditSocials,
       setEditWhoFor,
       setEditFaq,
-      setEditLandingTexts
+      setEditLandingTexts,
+      setEditModules
     );
   }, [initialSlug, location.pathname]);
 
@@ -240,6 +248,7 @@ export default function WhopDashboard() {
       setEditWhoFor,
       setEditFaq,
       setEditLandingTexts,
+      setEditModules,
       waitlistEnabled,
       waitlistQuestions,
       editLongDescription,
@@ -248,7 +257,8 @@ export default function WhopDashboard() {
       editSocials,
       editWhoFor,
       editFaq,
-      editLandingTexts
+      editLandingTexts,
+      editModules
     );
   };
 
@@ -305,7 +315,8 @@ export default function WhopDashboard() {
         setEditSocials,
         setEditWhoFor,
         setEditFaq,
-        setEditLandingTexts
+        setEditLandingTexts,
+        setEditModules
       );
     } catch {
       // handleRequestWaitlist throws errors for conflict or server error
@@ -441,6 +452,8 @@ export default function WhopDashboard() {
       setEditFaq={setEditFaq}
       editLandingTexts={editLandingTexts}
       setEditLandingTexts={setEditLandingTexts}
+      editModules={editModules}
+      setEditModules={setEditModules}
     />
   );
 }

--- a/src/pages/WhopDashboard/components/LandingPage.jsx
+++ b/src/pages/WhopDashboard/components/LandingPage.jsx
@@ -227,7 +227,7 @@ export default function LandingPage({
       </section>
 
       {/* FEATURES SECTION - dynamic */}
-      {features.length > 0 && (
+      {features.length > 0 && whopData.modules?.text !== false && (
         <section className="section features-section alt">
           <h2 className="section-title">{featuresTitle}</h2>
           <div className="features-grid">

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -48,7 +48,7 @@ export default function MemberMain({
       )}
 
       {/* CHAT */}
-      {activeTab === "Chat" && (
+      {activeTab === "Chat" && whopData.modules?.chat && (
         <div className="member-tab-content member-chat-tab">
           <ChatWindow
             whopId={whopData.id}
@@ -59,7 +59,7 @@ export default function MemberMain({
       )}
 
       {/* EARN */}
-      {activeTab === "Earn" && (
+      {activeTab === "Earn" && whopData.modules?.earn && (
         <div className="member-tab-content">
           <h3 className="member-subtitle">Earn</h3>
           {campaignsLoading ? (
@@ -179,6 +179,14 @@ export default function MemberMain({
               })}
             </ul>
           )}
+        </div>
+      )}
+
+      {/* COURSE */}
+      {activeTab === "Course" && whopData.modules?.course && (
+        <div className="member-tab-content">
+          <h3 className="member-subtitle">Course</h3>
+          <p className="member-text">Course content coming soon.</p>
         </div>
       )}
 

--- a/src/pages/WhopDashboard/components/MemberSidebar.jsx
+++ b/src/pages/WhopDashboard/components/MemberSidebar.jsx
@@ -44,18 +44,30 @@ export default function MemberSidebar({
         >
           <FaHome /> Home
         </button>
-        <button
-          className={`nav-button ${activeTab === "Chat" ? "active" : ""}`}
-          onClick={() => setActiveTab("Chat")}
-        >
-          <FaComments /> Chat
-        </button>
-        <button
-          className={`nav-button ${activeTab === "Earn" ? "active" : ""}`}
-          onClick={() => setActiveTab("Earn")}
-        >
-          <FaDollarSign /> Earn
-        </button>
+        {whopData.modules?.chat && (
+          <button
+            className={`nav-button ${activeTab === "Chat" ? "active" : ""}`}
+            onClick={() => setActiveTab("Chat")}
+          >
+            <FaComments /> Chat
+          </button>
+        )}
+        {whopData.modules?.earn && (
+          <button
+            className={`nav-button ${activeTab === "Earn" ? "active" : ""}`}
+            onClick={() => setActiveTab("Earn")}
+          >
+            <FaDollarSign /> Earn
+          </button>
+        )}
+        {whopData.modules?.course && (
+          <button
+            className={`nav-button ${activeTab === "Course" ? "active" : ""}`}
+            onClick={() => setActiveTab("Course")}
+          >
+            <FaTools /> Course
+          </button>
+        )}
         <button
           className={`nav-button ${activeTab === "Tools" ? "active" : ""}`}
           onClick={() => setActiveTab("Tools")}

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -12,6 +12,7 @@ import CampaignsSection from "./CampaignsSection";
 import MembersSection from "./MembersSection";
 import CampaignModal from "./CampaignModal";
 import OwnerTextMenu from "./OwnerTextMenu";
+import OwnerModules from "./OwnerModules";
 
 export default function OwnerMode({
   whopData,
@@ -66,6 +67,8 @@ export default function OwnerMode({
   setEditFaq,
   editLandingTexts,
   setEditLandingTexts,
+  editModules,
+  setEditModules,
 }) {
   if (!whopData) return null;
 
@@ -138,6 +141,13 @@ export default function OwnerMode({
           handleDelete={handleDelete}
           setViewAsMemberMode={setViewAsMemberMode}
           setIsCampaignModalOpen={setIsCampaignModalOpen}
+        />
+
+        {/* Modules section */}
+        <OwnerModules
+          editModules={editModules}
+          setEditModules={setEditModules}
+          isEditing={isEditing}
         />
 
         {/* Features section */}

--- a/src/pages/WhopDashboard/components/OwnerModules.jsx
+++ b/src/pages/WhopDashboard/components/OwnerModules.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+export default function OwnerModules({ editModules, setEditModules, isEditing }) {
+  if (!isEditing) return null;
+  const toggle = (key) => {
+    setEditModules((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+  const labels = {
+    chat: "Chat",
+    earn: "Earn",
+    discord: "Discord Access",
+    course: "Course",
+    text: "Text Features",
+  };
+  return (
+    <div className="owner-modules-section">
+      <h2>Modules</h2>
+      {Object.keys(labels).map((key) => (
+        <label key={key} className="module-toggle">
+          <input
+            type="checkbox"
+            checked={editModules[key]}
+            onChange={() => toggle(key)}
+          />
+          {labels[key]}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -19,7 +19,8 @@ export default async function fetchWhopData(
   setEditSocials,
   setEditWhoFor,
   setEditFaq,
-  setEditLandingTexts
+  setEditLandingTexts,
+  setEditModules
 ) {
   setLoading(true);
   setError("");
@@ -88,6 +89,15 @@ export default async function fetchWhopData(
         about_title: "",
         faq_title: "",
       });
+      setEditModules(
+        data.modules || {
+          chat: false,
+          earn: false,
+          discord: false,
+          course: false,
+          text: true,
+        }
+      );
 
       // ** Waitlist state **
       setWaitlistEnabled(Boolean(data.waitlist_enabled));

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -22,6 +22,7 @@ export default async function handleSaveWhop(
   setEditWhoFor,
   setEditFaq,
   setEditLandingTexts,
+  setEditModules,
   waitlistEnabled,         // new parameter
   waitlistQuestions,       // new parameter
   editLongDescription,
@@ -30,7 +31,8 @@ export default async function handleSaveWhop(
   editSocials,
   editWhoFor,
   editFaq,
-  editLandingTexts
+  editLandingTexts,
+  editModules
 ) {
   // 1) Validate name and description
   if (!editName.trim() || !editDescription.trim()) {
@@ -71,6 +73,7 @@ export default async function handleSaveWhop(
     who_for:            editWhoFor,
     faq:                editFaq,
     landing_texts:      editLandingTexts,
+    modules:            editModules,
   };
 
   try {
@@ -142,6 +145,15 @@ export default async function handleSaveWhop(
         about_title: "",
         faq_title: "",
       });
+      setEditModules(
+        data.modules || {
+          chat: false,
+          earn: false,
+          discord: false,
+          course: false,
+          text: true,
+        }
+      );
 
       // Rebuild features state
       const newFeatures = data.features.map((f, idx) => ({


### PR DESCRIPTION
## Summary
- introduce feature modules with new OwnerModules component
- enable module toggles in the setup workflow
- save modules to database and expose via API
- hide/show member sidebar tabs based on modules
- conditionally render member views and landing sections
- add SQL migration for new `modules` column

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869430d2680832caf7bfd5b531f0b5a