### PR TITLE
Implement course module with editable steps

### DIFF
--- a/php/get_whop.php
+++ b/php/get_whop.php
@@ -185,6 +185,7 @@ if ($method === 'GET') {
                   w.faq,
                   w.landing_texts,
                   w.modules,
+                  w.course_steps,
                   w.created_at
                 FROM whops AS w
                 JOIN users4 AS u ON w.owner_id = u.id
@@ -274,7 +275,8 @@ if ($method === 'GET') {
                     "waitlist_enabled"       => (int)$w['waitlist_enabled'],
                     "waitlist_questions"     => json_decode($w['waitlist_questions'], true) ?: [],
                     "landing_texts"         => json_decode($w['landing_texts'], true) ?: new stdClass(),
-                    "modules"               => json_decode($w['modules'], true) ?: new stdClass(),
+                   "modules"               => json_decode($w['modules'], true) ?: new stdClass(),
+                    "course_steps"          => json_decode($w['course_steps'], true) ?: [],
                     "website_url"            => $w['website_url'],
                     "socials"                => json_decode($w['socials'], true) ?: new stdClass(),
                     "who_for"                => json_decode($w['who_for'], true)   ?: [],

--- a/php/update_whop.php
+++ b/php/update_whop.php
@@ -152,6 +152,7 @@ $who_for_json   = isset($data['who_for']) ? json_encode($data['who_for'], JSON_U
 $faq_json       = isset($data['faq']) ? json_encode($data['faq'], JSON_UNESCAPED_UNICODE) : json_encode([], JSON_UNESCAPED_UNICODE);
 $landing_json   = isset($data['landing_texts']) ? json_encode($data['landing_texts'], JSON_UNESCAPED_UNICODE) : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
 $modules_json   = isset($data['modules']) ? json_encode($data['modules'], JSON_UNESCAPED_UNICODE) : json_encode(new stdClass(), JSON_UNESCAPED_UNICODE);
+$course_json    = isset($data['course_steps']) ? json_encode($data['course_steps'], JSON_UNESCAPED_UNICODE) : json_encode([], JSON_UNESCAPED_UNICODE);
 
 // 12) Update the Whop record
 try {
@@ -173,7 +174,8 @@ try {
                who_for            = :who_for,
                faq                = :faq,
                landing_texts      = :landing_texts,
-               modules            = :modules
+               modules            = :modules,
+               course_steps       = :course_steps
         WHERE id = :id
     ");
     $updStmt->execute([
@@ -194,6 +196,7 @@ try {
         ':faq'              => $faq_json,
         ':landing_texts'    => $landing_json,
         ':modules'          => $modules_json,
+        ':course_steps'     => $course_json,
         ':id'               => $whopId
     ]);
 } catch (PDOException $e) {

--- a/sql/update_whops_add_course.sql
+++ b/sql/update_whops_add_course.sql
@@ -1,0 +1,2 @@
+ALTER TABLE whops
+  ADD COLUMN course_steps TEXT DEFAULT NULL;

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -12,6 +12,7 @@ import handleLeave from "./handleLeave";
 import handleBannerUpload from "./handleBannerUpload";
 import handleFeatureImageUpload from "./handleFeatureImageUpload";
 import manageFeatures from "./manageFeatures";
+import manageCourse from "./manageCourse";
 import handleSlugSave from "./handleSlugSave";
 import handleSaveWhop from "./handleSaveWhop";
 import handleDeleteWhop from "./handleDeleteWhop";
@@ -64,6 +65,7 @@ export default function WhopDashboard() {
 
   // Feature-edit
   const [editFeatures, setEditFeatures] = useState([]);
+  const [editCourseSteps, setEditCourseSteps] = useState([{ id: 1, title: "", content: "" }]);
   const [editModules, setEditModules] = useState({
     chat: false,
     earn: false,
@@ -123,6 +125,7 @@ export default function WhopDashboard() {
       setEditBannerUrl,
       setNewSlugValue,
       setEditFeatures,
+      setEditCourseSteps,
       fetchCampaignsBound,
       setWaitlistEnabled,
       setWaitlistQuestions,
@@ -133,7 +136,8 @@ export default function WhopDashboard() {
       setEditWhoFor,
       setEditFaq,
       setEditLandingTexts,
-      setEditModules
+      setEditModules,
+      setEditCourseSteps
     );
   }, [initialSlug, location.pathname]);
 
@@ -219,6 +223,11 @@ export default function WhopDashboard() {
     showNotification
   );
 
+  const { addStep, removeStep, handleCourseChange } = manageCourse(
+    editCourseSteps,
+    setEditCourseSteps
+  );
+
   // 8️⃣ Slug save
   const onSlugSave = async () => {
     await handleSlugSave(whopData, newSlugValue, showNotification, setSlugError, navigate);
@@ -258,7 +267,8 @@ export default function WhopDashboard() {
       editWhoFor,
       editFaq,
       editLandingTexts,
-      editModules
+      editModules,
+      editCourseSteps
     );
   };
 
@@ -306,6 +316,7 @@ export default function WhopDashboard() {
         setEditBannerUrl,
         setNewSlugValue,
         setEditFeatures,
+        setEditCourseSteps,
         fetchCampaignsBound,
         setWaitlistEnabled,
         setWaitlistQuestions,
@@ -423,6 +434,10 @@ export default function WhopDashboard() {
       handleImageChange={onFeatureImageUpload}
       removeFeature={removeFeature}
       addFeature={addFeature}
+      editCourseSteps={editCourseSteps}
+      handleCourseChange={handleCourseChange}
+      removeStep={removeStep}
+      addStep={addStep}
       campaigns={campaigns}
       campaignsLoading={campaignsLoading}
       campaignsError={campaignsError}

--- a/src/pages/WhopDashboard/components/CourseSection.jsx
+++ b/src/pages/WhopDashboard/components/CourseSection.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { FaPlus, FaTrash } from "react-icons/fa";
+
+export default function CourseSection({
+  isEditing,
+  courseSteps,
+  handleCourseChange,
+  addStep,
+  removeStep,
+}) {
+  const steps = Array.isArray(courseSteps) ? courseSteps : [];
+  return (
+    <div className="course-section">
+      <h2 className="course-section-title">Course</h2>
+      {isEditing ? (
+        <>
+          {steps.map((step, idx) => (
+            <div key={step.id} className="course-step-edit">
+              <div className="course-step-header">
+                <span>Step {idx + 1}</span>
+                {steps.length > 1 && (
+                  <button
+                    type="button"
+                    className="course-remove-btn"
+                    onClick={() => removeStep(step.id)}
+                  >
+                    <FaTrash /> Remove
+                  </button>
+                )}
+              </div>
+              <input
+                type="text"
+                className="course-input"
+                placeholder="Step title"
+                value={step.title}
+                onChange={(e) => handleCourseChange(step.id, "title", e.target.value)}
+              />
+              <textarea
+                className="course-textarea"
+                rows="3"
+                placeholder="Step content"
+                value={step.content}
+                onChange={(e) => handleCourseChange(step.id, "content", e.target.value)}
+              />
+            </div>
+          ))}
+          <button type="button" className="course-add-btn" onClick={addStep}>
+            <FaPlus /> Add Step
+          </button>
+        </>
+      ) : (
+        <ol className="course-step-list">
+          {steps.map((step, idx) => (
+            <li key={idx} className="course-step">
+              <h3 className="course-step-title">{step.title}</h3>
+              <p className="course-step-content">{step.content}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -186,7 +186,14 @@ export default function MemberMain({
       {activeTab === "Course" && whopData.modules?.course && (
         <div className="member-tab-content">
           <h3 className="member-subtitle">Course</h3>
-          <p className="member-text">Course content coming soon.</p>
+          <ol className="course-step-list">
+            {whopData.course_steps?.map((step, idx) => (
+              <li key={idx} className="course-step">
+                <h4 className="course-step-title">{step.title}</h4>
+                <p className="course-step-content">{step.content}</p>
+              </li>
+            ))}
+          </ol>
         </div>
       )}
 

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -8,6 +8,7 @@ import OwnerHeader from "./OwnerHeader";
 import OwnerSlugPrice from "./OwnerSlugPrice";
 import OwnerActionButtons from "./OwnerActionButtons";
 import FeaturesSection from "./FeaturesSection";
+import CourseSection from "./CourseSection";
 import CampaignsSection from "./CampaignsSection";
 import MembersSection from "./MembersSection";
 import CampaignModal from "./CampaignModal";
@@ -42,6 +43,10 @@ export default function OwnerMode({
   handleImageChange,
   removeFeature,
   addFeature,
+  editCourseSteps,
+  handleCourseChange,
+  removeStep,
+  addStep,
   campaigns,
   campaignsLoading,
   campaignsError,
@@ -160,6 +165,16 @@ export default function OwnerMode({
           removeFeature={removeFeature}
           addFeature={addFeature}
         />
+
+        {editModules.course && (
+          <CourseSection
+            isEditing={isEditing}
+            courseSteps={editCourseSteps}
+            handleCourseChange={handleCourseChange}
+            removeStep={removeStep}
+            addStep={addStep}
+          />
+        )}
 
         {/* Campaigns section (only for owners) */}
         {whopData.is_owner && (

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -13,6 +13,7 @@ export default async function fetchWhopData(
   fetchCampaigns,        // bound version
   setWaitlistEnabled,    // newly added
   setWaitlistQuestions,  // newly added
+  setEditCourseSteps,
   setEditLongDescription,
   setEditAboutBio,
   setEditWebsiteUrl,
@@ -64,6 +65,16 @@ export default async function fetchWhopData(
           isUploading: false,
           error: "",
         }))
+      );
+
+      setEditCourseSteps(
+        Array.isArray(data.course_steps) && data.course_steps.length
+          ? data.course_steps.map((s, i) => ({
+              id: i + 1,
+              title: s.title || "",
+              content: s.content || "",
+            }))
+          : [{ id: 1, title: "", content: "" }]
       );
 
       setEditLongDescription(data.long_description || "");

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -23,6 +23,7 @@ export default async function handleSaveWhop(
   setEditFaq,
   setEditLandingTexts,
   setEditModules,
+  setEditCourseSteps,
   waitlistEnabled,         // new parameter
   waitlistQuestions,       // new parameter
   editLongDescription,
@@ -32,7 +33,8 @@ export default async function handleSaveWhop(
   editWhoFor,
   editFaq,
   editLandingTexts,
-  editModules
+  editModules,
+  editCourseSteps
 ) {
   // 1) Validate name and description
   if (!editName.trim() || !editDescription.trim()) {
@@ -74,6 +76,10 @@ export default async function handleSaveWhop(
     faq:                editFaq,
     landing_texts:      editLandingTexts,
     modules:            editModules,
+    course_steps:       editCourseSteps.map(s => ({
+                          title: s.title.trim(),
+                          content: s.content.trim(),
+                        })),
   };
 
   try {
@@ -165,6 +171,16 @@ export default async function handleSaveWhop(
         error:       "",
       }));
       setEditFeatures(newFeatures);
+
+      setEditCourseSteps(
+        Array.isArray(data.course_steps) && data.course_steps.length
+          ? data.course_steps.map((s, i) => ({
+              id: i + 1,
+              title: s.title || "",
+              content: s.content || "",
+            }))
+          : [{ id: 1, title: "", content: "" }]
+      );
 
       setError("");
       setSlugError("");

--- a/src/pages/WhopDashboard/manageCourse.js
+++ b/src/pages/WhopDashboard/manageCourse.js
@@ -1,0 +1,27 @@
+// src/pages/WhopDashboard/manageCourse.js
+
+export default function manageCourse(editCourseSteps, setEditCourseSteps) {
+  const addStep = () => {
+    const newId =
+      editCourseSteps.length > 0
+        ? Math.max(...editCourseSteps.map((s) => s.id)) + 1
+        : 1;
+    setEditCourseSteps((prev) => [
+      ...prev,
+      { id: newId, title: "", content: "" },
+    ]);
+  };
+
+  const removeStep = (id) => {
+    if (editCourseSteps.length <= 1) return;
+    setEditCourseSteps((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  const handleCourseChange = (id, field, value) => {
+    setEditCourseSteps((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, [field]: value } : s))
+    );
+  };
+
+  return { addStep, removeStep, handleCourseChange };
+}


### PR DESCRIPTION
## Summary
- add CourseSection component and manageCourse helpers
- store course steps in database and API
- include course data in save/get endpoints
- extend dashboard UI to edit and display course steps
- add SQL migration for course_steps field

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686948227460832cbcbb192420695430