### PR TITLE
Add basic video course features

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -11,6 +11,7 @@ import handleJoinFree from "./handleJoinFree";
 import handleLeave from "./handleLeave";
 import handleBannerUpload from "./handleBannerUpload";
 import handleFeatureImageUpload from "./handleFeatureImageUpload";
+import handleCourseVideoUpload from "./handleCourseVideoUpload";
 import manageFeatures from "./manageFeatures";
 import manageCourse from "./manageCourse";
 import handleSlugSave from "./handleSlugSave";
@@ -65,7 +66,9 @@ export default function WhopDashboard() {
 
   // Feature-edit
   const [editFeatures, setEditFeatures] = useState([]);
-  const [editCourseSteps, setEditCourseSteps] = useState([{ id: 1, title: "", content: "" }]);
+  const [editCourseSteps, setEditCourseSteps] = useState([
+    { id: 1, title: "", content: "", videoUrl: "", isUploading: false, error: "" }
+  ]);
   const [editModules, setEditModules] = useState({
     chat: false,
     earn: false,
@@ -214,6 +217,9 @@ export default function WhopDashboard() {
   };
   const onFeatureImageUpload = async (id, file) => {
     await handleFeatureImageUpload(id, file, setEditFeatures, showNotification);
+  };
+  const onCourseVideoUpload = async (id, file) => {
+    await handleCourseVideoUpload(id, file, setEditCourseSteps, showNotification);
   };
 
   // 7️⃣ Manage features
@@ -436,6 +442,7 @@ export default function WhopDashboard() {
       addFeature={addFeature}
       editCourseSteps={editCourseSteps}
       handleCourseChange={handleCourseChange}
+      handleVideoUpload={onCourseVideoUpload}
       removeStep={removeStep}
       addStep={addStep}
       campaigns={campaigns}

--- a/src/pages/WhopDashboard/components/CourseSection.jsx
+++ b/src/pages/WhopDashboard/components/CourseSection.jsx
@@ -5,6 +5,7 @@ export default function CourseSection({
   isEditing,
   courseSteps,
   handleCourseChange,
+  handleVideoUpload,
   addStep,
   removeStep,
 }) {
@@ -42,6 +43,17 @@ export default function CourseSection({
                 value={step.content}
                 onChange={(e) => handleCourseChange(step.id, "content", e.target.value)}
               />
+              <input
+                type="file"
+                accept="video/*"
+                className="course-input"
+                onChange={(e) => handleVideoUpload(step.id, e.target.files[0])}
+              />
+              {step.isUploading && <div className="uploading-msg">Uploading...</div>}
+              {step.videoUrl && !step.isUploading && (
+                <video src={step.videoUrl} controls className="course-video-preview" />
+              )}
+              {step.error && <div className="course-error">{step.error}</div>}
             </div>
           ))}
           <button type="button" className="course-add-btn" onClick={addStep}>
@@ -53,6 +65,9 @@ export default function CourseSection({
           {steps.map((step, idx) => (
             <li key={idx} className="course-step">
               <h3 className="course-step-title">{step.title}</h3>
+              {step.videoUrl && (
+                <video src={step.videoUrl} controls className="course-video" />
+              )}
               <p className="course-step-content">{step.content}</p>
             </li>
           ))}

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -1,6 +1,6 @@
 // src/pages/WhopDashboard/components/MemberMain.jsx
 
-import React from "react";
+import React, { useState } from "react";
 import "../../../styles/whop-dashboard/_member.scss";
 import ChatWindow from "../../../components/Chat/ChatWindow";
 import ReviewSection from "../../../components/ReviewSection";
@@ -13,6 +13,18 @@ export default function MemberMain({
   campaignsError,
   onSelectCampaign,
 }) {
+  const [completedSteps, setCompletedSteps] = useState([]);
+
+  const toggleStep = (idx) => {
+    setCompletedSteps((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+    );
+  };
+
+  const totalSteps = whopData.course_steps ? whopData.course_steps.length : 0;
+  const percent = totalSteps
+    ? Math.round((completedSteps.length / totalSteps) * 100)
+    : 0;
   return (
     <div className="member-main">
       {/* HOME */}
@@ -186,11 +198,25 @@ export default function MemberMain({
       {activeTab === "Course" && whopData.modules?.course && (
         <div className="member-tab-content">
           <h3 className="member-subtitle">Course</h3>
+          <div className="course-progress-bar">
+            <div className="course-progress-fill" style={{ width: `${percent}%` }} />
+          </div>
+          <p className="course-progress-text">{percent}% complete</p>
           <ol className="course-step-list">
             {whopData.course_steps?.map((step, idx) => (
               <li key={idx} className="course-step">
                 <h4 className="course-step-title">{step.title}</h4>
+                {step.video_url && (
+                  <video src={step.video_url} controls className="course-video" />
+                )}
                 <p className="course-step-content">{step.content}</p>
+                <button
+                  type="button"
+                  className="course-complete-btn"
+                  onClick={() => toggleStep(idx)}
+                >
+                  {completedSteps.includes(idx) ? "Completed" : "Mark Complete"}
+                </button>
               </li>
             ))}
           </ol>

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -45,6 +45,7 @@ export default function OwnerMode({
   addFeature,
   editCourseSteps,
   handleCourseChange,
+  handleVideoUpload,
   removeStep,
   addStep,
   campaigns,
@@ -171,6 +172,7 @@ export default function OwnerMode({
             isEditing={isEditing}
             courseSteps={editCourseSteps}
             handleCourseChange={handleCourseChange}
+            handleVideoUpload={handleVideoUpload}
             removeStep={removeStep}
             addStep={addStep}
           />

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -73,8 +73,11 @@ export default async function fetchWhopData(
               id: i + 1,
               title: s.title || "",
               content: s.content || "",
+              videoUrl: s.video_url || "",
+              isUploading: false,
+              error: "",
             }))
-          : [{ id: 1, title: "", content: "" }]
+          : [{ id: 1, title: "", content: "", videoUrl: "", isUploading: false, error: "" }]
       );
 
       setEditLongDescription(data.long_description || "");

--- a/src/pages/WhopDashboard/handleCourseVideoUpload.js
+++ b/src/pages/WhopDashboard/handleCourseVideoUpload.js
@@ -1,0 +1,67 @@
+// src/pages/WhopDashboard/handleCourseVideoUpload.js
+
+export default async function handleCourseVideoUpload(
+  id,
+  file,
+  setEditCourseSteps,
+  showNotification
+) {
+  if (!file) return;
+  const maxSize = 100 * 1024 * 1024; // 100 MB limit
+  if (file.size > maxSize) {
+    setEditCourseSteps(prev =>
+      prev.map(s =>
+        s.id === id ? { ...s, error: "Max file size is 100 MB.", isUploading: false } : s
+      )
+    );
+    return;
+  }
+  if (!file.type.startsWith("video/")) {
+    setEditCourseSteps(prev =>
+      prev.map(s =>
+        s.id === id ? { ...s, error: "Please select a video file.", isUploading: false } : s
+      )
+    );
+    return;
+  }
+
+  setEditCourseSteps(prev =>
+    prev.map(s => (s.id === id ? { ...s, isUploading: true, error: "" } : s))
+  );
+
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("upload_preset", "unsigned_profile_avatars");
+
+  try {
+    const res = await fetch(
+      `https://api.cloudinary.com/v1_1/dv6igcvz8/upload`,
+      {
+        method: "POST",
+        body: formData,
+      }
+    );
+    if (!res.ok) throw new Error(`Cloudinary error: ${res.status}`);
+    const data = await res.json();
+    if (!data.secure_url) throw new Error("Missing secure_url.");
+
+    setEditCourseSteps(prev =>
+      prev.map(s =>
+        s.id === id
+          ? { ...s, videoUrl: data.secure_url, isUploading: false, error: "" }
+          : s
+      )
+    );
+    showNotification({ type: "success", message: "Video uploaded." });
+  } catch (err) {
+    console.error("Course video upload error:", err);
+    setEditCourseSteps(prev =>
+      prev.map(s =>
+        s.id === id
+          ? { ...s, videoUrl: "", isUploading: false, error: "Upload failed." }
+          : s
+      )
+    );
+    showNotification({ type: "error", message: "Failed to upload video." });
+  }
+}

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -79,6 +79,7 @@ export default async function handleSaveWhop(
     course_steps:       editCourseSteps.map(s => ({
                           title: s.title.trim(),
                           content: s.content.trim(),
+                          video_url: s.videoUrl || "",
                         })),
   };
 
@@ -178,8 +179,20 @@ export default async function handleSaveWhop(
               id: i + 1,
               title: s.title || "",
               content: s.content || "",
+              videoUrl: s.video_url || "",
+              isUploading: false,
+              error: "",
             }))
-          : [{ id: 1, title: "", content: "" }]
+          : [
+              {
+                id: 1,
+                title: "",
+                content: "",
+                videoUrl: "",
+                isUploading: false,
+                error: "",
+              },
+            ]
       );
 
       setError("");

--- a/src/pages/WhopDashboard/manageCourse.js
+++ b/src/pages/WhopDashboard/manageCourse.js
@@ -8,7 +8,7 @@ export default function manageCourse(editCourseSteps, setEditCourseSteps) {
         : 1;
     setEditCourseSteps((prev) => [
       ...prev,
-      { id: newId, title: "", content: "" },
+      { id: newId, title: "", content: "", videoUrl: "", isUploading: false, error: "" },
     ]);
   };
 

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -436,14 +436,51 @@
         }
       }
 
-      .member-error {
-        color: var(--error-color);
-        font-size: 1rem;
-        margin-top: var(--spacing-sm);
-        text-align: center;
+    .member-error {
+      color: var(--error-color);
+      font-size: 1rem;
+      margin-top: var(--spacing-sm);
+      text-align: center;
+    }
+
+    .course-progress-bar {
+      width: 100%;
+      height: 0.5rem;
+      background: var(--border-color);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      margin-bottom: var(--spacing-sm);
+
+      .course-progress-fill {
+        height: 100%;
+        background: var(--primary-color);
+        width: 0;
       }
     }
+
+    .course-progress-text {
+      text-align: center;
+      margin-bottom: var(--spacing-md);
+      color: var(--text-color);
+    }
+
+    .course-video,
+    .course-video-preview {
+      width: 100%;
+      max-width: 480px;
+      margin: var(--spacing-sm) 0;
+    }
+
+    .course-complete-btn {
+      margin-top: var(--spacing-xs);
+      padding: 0.25rem 0.5rem;
+      border-radius: var(--radius-base);
+      border: 1px solid var(--border-color);
+      background: var(--surface-color);
+      cursor: pointer;
+    }
   }
+}
 }
 
 @media (max-width: 768px) {

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -784,3 +784,52 @@
     transform: translateY(-1px);
   }
 }
+
+.course-section {
+  margin-bottom: var(--spacing-lg);
+
+  .course-section-title {
+    font-size: 1.5rem;
+    text-align: center;
+    margin-bottom: var(--spacing-md);
+    color: var(--text-color);
+  }
+
+  .course-step-edit {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-md);
+  }
+
+  .course-input {
+    padding: var(--spacing-xs);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-base);
+  }
+
+  .course-textarea {
+    padding: var(--spacing-xs);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-base);
+  }
+
+  .course-add-btn,
+  .course-remove-btn {
+    padding: 0.25rem 0.5rem;
+    border: none;
+    background: var(--primary-color);
+    color: #fff;
+    border-radius: var(--radius-base);
+    cursor: pointer;
+  }
+
+  .course-video-preview {
+    width: 100%;
+    max-width: 480px;
+  }
+
+  .course-error {
+    color: var(--error-color);
+  }
+}


### PR DESCRIPTION
## Summary
- enable uploading course videos via Cloudinary
- store video URLs for each course step
- show course progress and completion UI for members
- style course management sections

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68699c9cbe78832cb558ad7ee8ef5c50