### PR TITLE
Fix waitlist save arg mismatch

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -264,6 +264,7 @@ export default function WhopDashboard() {
       setEditFaq,
       setEditLandingTexts,
       setEditModules,
+      setEditCourseSteps,
       waitlistEnabled,
       waitlistQuestions,
       editLongDescription,


### PR DESCRIPTION
## Summary
- pass `setEditCourseSteps` to `handleSaveWhop`

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869a386c5e4832c938c60eee91cef64