### PR TITLE
Enhance course viewer

### DIFF
--- a/php/get_whop.php
+++ b/php/get_whop.php
@@ -255,6 +255,14 @@ if ($method === 'GET') {
             $is_accepted_waitlist = ($r && $r['status'] === 'accepted') ? 1 : 0;
             $waitlist_answers     = $r['answers_json'] ? json_decode($r['answers_json'], true) : [];
 
+            // course progress for this user
+            $cp = $pdo->prepare(
+                "SELECT completed_steps FROM whop_course_progress WHERE user_id = :uid AND whop_id = :wid"
+            );
+            $cp->execute(['uid' => $user_id, 'wid' => $w['id']]);
+            $cpRow = $cp->fetch(PDO::FETCH_ASSOC);
+            $course_progress = $cpRow ? json_decode($cpRow['completed_steps'], true) : [];
+
             // respond with data
             echo json_encode([
                 "status" => "success",
@@ -277,6 +285,7 @@ if ($method === 'GET') {
                     "landing_texts"         => json_decode($w['landing_texts'], true) ?: new stdClass(),
                    "modules"               => json_decode($w['modules'], true) ?: new stdClass(),
                     "course_steps"          => json_decode($w['course_steps'], true) ?: [],
+                    "course_progress"       => $course_progress,
                     "website_url"            => $w['website_url'],
                     "socials"                => json_decode($w['socials'], true) ?: new stdClass(),
                     "who_for"                => json_decode($w['who_for'], true)   ?: [],

--- a/php/save_course_progress.php
+++ b/php/save_course_progress.php
@@ -1,0 +1,68 @@
+<?php
+// php/save_course_progress.php
+
+header("Access-Control-Allow-Origin: http://localhost:3000");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Methods: POST, OPTIONS");
+header("Access-Control-Allow-Headers: Content-Type");
+header("Content-Type: application/json; charset=UTF-8");
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+require_once __DIR__ . '/session_init.php';
+$user_id = $_SESSION['user_id'] ?? 0;
+if ($user_id <= 0) {
+    http_response_code(401);
+    echo json_encode(["status" => "error", "message" => "Unauthorized"]);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$whop_id = isset($input['whop_id']) ? intval($input['whop_id']) : 0;
+$steps   = isset($input['completed_steps']) && is_array($input['completed_steps'])
+    ? array_values($input['completed_steps'])
+    : null;
+if ($whop_id <= 0 || $steps === null) {
+    http_response_code(400);
+    echo json_encode(["status" => "error", "message" => "Invalid input"]);
+    exit;
+}
+
+require_once __DIR__ . '/config_login.php';
+try {
+    $pdo = new PDO(
+        "mysql:host={$servername};dbname={$database};charset=utf8mb4",
+        $db_username,
+        $db_password,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+
+    // verify membership
+    $m1 = $pdo->prepare("SELECT COUNT(*) FROM whop_members WHERE user_id = :uid AND whop_id = :wid");
+    $m1->execute(['uid' => $user_id, 'wid' => $whop_id]);
+    $is_member = $m1->fetchColumn() > 0;
+
+    $m2 = $pdo->prepare("SELECT COUNT(*) FROM memberships WHERE user_id = :uid AND whop_id = :wid AND status = 'active'");
+    $m2->execute(['uid' => $user_id, 'wid' => $whop_id]);
+    $is_member = $is_member || ($m2->fetchColumn() > 0);
+
+    if (!$is_member) {
+        http_response_code(403);
+        echo json_encode(["status" => "error", "message" => "Not a member"]);
+        exit;
+    }
+
+    $json = json_encode($steps, JSON_UNESCAPED_UNICODE);
+    $stmt = $pdo->prepare(
+        "INSERT INTO whop_course_progress (user_id, whop_id, completed_steps) VALUES (:uid, :wid, :steps)
+         ON DUPLICATE KEY UPDATE completed_steps = VALUES(completed_steps), updated_at = CURRENT_TIMESTAMP"
+    );
+    $stmt->execute(['uid' => $user_id, 'wid' => $whop_id, 'steps' => $json]);
+
+    echo json_encode(["status" => "success"]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(["status" => "error", "message" => "DB error: " . $e->getMessage()]);
+}

--- a/sql/create_whop_course_progress.sql
+++ b/sql/create_whop_course_progress.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS whop_course_progress (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  user_id INT UNSIGNED NOT NULL,
+  whop_id INT UNSIGNED NOT NULL,
+  completed_steps TEXT DEFAULT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_user_whop (user_id, whop_id),
+  INDEX idx_user_id (user_id),
+  INDEX idx_whop_id (whop_id)
+);

--- a/src/components/CourseViewer.jsx
+++ b/src/components/CourseViewer.jsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from "react";
+import "../styles/whop-dashboard/_member.scss";
+
+export default function CourseViewer({ steps = [], initialCompleted = [], whopId }) {
+  const [current, setCurrent] = useState(0);
+  const [completed, setCompleted] = useState(initialCompleted);
+
+  useEffect(() => {
+    setCompleted(initialCompleted);
+  }, [initialCompleted]);
+
+  const total = steps.length;
+  const percent = total ? Math.round((completed.length / total) * 100) : 0;
+
+  function gotoStep(i) {
+    if (i >= 0 && i < total) setCurrent(i);
+  }
+
+  async function save(newCompleted) {
+    setCompleted(newCompleted);
+    try {
+      await fetch("https://app.byxbot.com/php/save_course_progress.php", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ whop_id: whopId, completed_steps: newCompleted })
+      });
+    } catch {}
+  }
+
+  function toggleComplete(idx) {
+    const arr = completed.includes(idx)
+      ? completed.filter((i) => i !== idx)
+      : [...completed, idx];
+    save(arr);
+  }
+
+  function restart() {
+    setCurrent(0);
+    save([]);
+  }
+
+  if (!steps.length) return <p>No steps.</p>;
+
+  const step = steps[current];
+
+  return (
+    <div className="course-viewer">
+      <div className="course-progress-bar">
+        <div className="course-progress-fill" style={{ width: `${percent}%` }} />
+      </div>
+      <p className="course-progress-text">{percent}% complete</p>
+      <div className="course-nav">
+        {steps.map((_, i) => (
+          <button
+            key={i}
+            className={`course-nav-step ${i === current ? "active" : ""}`}
+            onClick={() => gotoStep(i)}
+          >
+            {i + 1}
+          </button>
+        ))}
+      </div>
+      <div className="course-step">
+        <h4 className="course-step-title">{step.title}</h4>
+        {step.video_url && (
+          <video src={step.video_url} controls className="course-video" />
+        )}
+        <p className="course-step-content">{step.content}</p>
+        <button type="button" className="course-complete-btn" onClick={() => toggleComplete(current)}>
+          {completed.includes(current) ? "Completed" : "Mark Complete"}
+        </button>
+      </div>
+      <div className="course-controls">
+        <button className="course-control-btn" onClick={() => gotoStep(current - 1)} disabled={current === 0}>
+          Back
+        </button>
+        <button className="course-control-btn" onClick={() => gotoStep(current + 1)} disabled={current === total - 1}>
+          Next
+        </button>
+      </div>
+      <button className="course-restart-btn" onClick={restart}>
+        Restart Course
+      </button>
+    </div>
+  );
+}

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -1,9 +1,10 @@
 // src/pages/WhopDashboard/components/MemberMain.jsx
 
-import React, { useState } from "react";
+import React from "react";
 import "../../../styles/whop-dashboard/_member.scss";
 import ChatWindow from "../../../components/Chat/ChatWindow";
 import ReviewSection from "../../../components/ReviewSection";
+import CourseViewer from "../../../components/CourseViewer";
 
 export default function MemberMain({
   whopData,
@@ -13,18 +14,6 @@ export default function MemberMain({
   campaignsError,
   onSelectCampaign,
 }) {
-  const [completedSteps, setCompletedSteps] = useState([]);
-
-  const toggleStep = (idx) => {
-    setCompletedSteps((prev) =>
-      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
-    );
-  };
-
-  const totalSteps = whopData.course_steps ? whopData.course_steps.length : 0;
-  const percent = totalSteps
-    ? Math.round((completedSteps.length / totalSteps) * 100)
-    : 0;
   return (
     <div className="member-main">
       {/* HOME */}
@@ -198,28 +187,11 @@ export default function MemberMain({
       {activeTab === "Course" && whopData.modules?.course && (
         <div className="member-tab-content">
           <h3 className="member-subtitle">Course</h3>
-          <div className="course-progress-bar">
-            <div className="course-progress-fill" style={{ width: `${percent}%` }} />
-          </div>
-          <p className="course-progress-text">{percent}% complete</p>
-          <ol className="course-step-list">
-            {whopData.course_steps?.map((step, idx) => (
-              <li key={idx} className="course-step">
-                <h4 className="course-step-title">{step.title}</h4>
-                {step.video_url && (
-                  <video src={step.video_url} controls className="course-video" />
-                )}
-                <p className="course-step-content">{step.content}</p>
-                <button
-                  type="button"
-                  className="course-complete-btn"
-                  onClick={() => toggleStep(idx)}
-                >
-                  {completedSteps.includes(idx) ? "Completed" : "Mark Complete"}
-                </button>
-              </li>
-            ))}
-          </ol>
+          <CourseViewer
+            steps={whopData.course_steps || []}
+            initialCompleted={whopData.course_progress || []}
+            whopId={whopData.id}
+          />
         </div>
       )}
 

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -479,6 +479,41 @@
       background: var(--surface-color);
       cursor: pointer;
     }
+
+    .course-nav {
+      display: flex;
+      gap: var(--spacing-xs);
+      margin-bottom: var(--spacing-sm);
+
+      .course-nav-step {
+        padding: 0.25rem 0.5rem;
+        border: 1px solid var(--border-color);
+        background: var(--surface-color);
+        &.active {
+          background: var(--primary-color);
+          color: var(--surface-color);
+        }
+      }
+    }
+
+    .course-controls {
+      margin-top: var(--spacing-sm);
+      display: flex;
+      gap: var(--spacing-xs);
+
+      .course-control-btn {
+        padding: 0.25rem 0.5rem;
+        border: 1px solid var(--border-color);
+        background: var(--surface-color);
+      }
+    }
+
+    .course-restart-btn {
+      margin-top: var(--spacing-sm);
+      padding: 0.25rem 0.5rem;
+      border: 1px solid var(--border-color);
+      background: var(--surface-color);
+    }
   }
 }
 }


### PR DESCRIPTION
## Summary
- create DB schema for member course progress
- implement API to save progress
- expose `course_progress` in `get_whop.php`
- add React `CourseViewer` component
- use the new course viewer in MemberMain
- style navigation and control buttons

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a66a92c0832cb2ebda050f4e85ef