### PR TITLE
Improve course viewer layout and file support

### DIFF
--- a/src/components/CourseViewer.jsx
+++ b/src/components/CourseViewer.jsx
@@ -46,42 +46,52 @@ export default function CourseViewer({ steps = [], initialCompleted = [], whopId
 
   return (
     <div className="course-viewer">
-      <div className="course-progress-bar">
-        <div className="course-progress-fill" style={{ width: `${percent}%` }} />
-      </div>
-      <p className="course-progress-text">{percent}% complete</p>
-      <div className="course-nav">
-        {steps.map((_, i) => (
-          <button
-            key={i}
-            className={`course-nav-step ${i === current ? "active" : ""}`}
-            onClick={() => gotoStep(i)}
-          >
-            {i + 1}
-          </button>
-        ))}
-      </div>
-      <div className="course-step">
+      <aside className="course-sidebar">
+        <div className="course-progress-bar">
+          <div className="course-progress-fill" style={{ width: `${percent}%` }} />
+        </div>
+        <p className="course-progress-text">{percent}% complete</p>
+        <ul className="course-steps-list">
+          {steps.map((s, i) => (
+            <li key={i} className={`course-sidebar-step ${i === current ? "active" : ""}`}> 
+              <button onClick={() => gotoStep(i)}>
+                <span className="step-index">{i + 1}</span>
+                <span className="step-title">{s.title}</span>
+                {completed.includes(i) && <span className="step-complete">✓</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <div className="course-content">
         <h4 className="course-step-title">{step.title}</h4>
-        {step.video_url && (
-          <video src={step.video_url} controls className="course-video" />
-        )}
+        {step.file_url || step.video_url ? (
+          (step.file_type || "").startsWith("video/") || step.video_url ? (
+            <video src={step.file_url || step.video_url} controls className="course-video" />
+          ) : step.file_type === "application/pdf" ? (
+            <embed src={step.file_url} type="application/pdf" className="course-pdf" />
+          ) : (
+            <a href={step.file_url} target="_blank" rel="noopener noreferrer" download>
+              Download File
+            </a>
+          )
+        ) : null}
         <p className="course-step-content">{step.content}</p>
         <button type="button" className="course-complete-btn" onClick={() => toggleComplete(current)}>
           {completed.includes(current) ? "Completed" : "Mark Complete"}
         </button>
-      </div>
-      <div className="course-controls">
-        <button className="course-control-btn" onClick={() => gotoStep(current - 1)} disabled={current === 0}>
-          Back
+        <div className="course-controls">
+          <button className="course-control-btn" onClick={() => gotoStep(current - 1)} disabled={current === 0}>
+            Back
+          </button>
+          <button className="course-control-btn" onClick={() => gotoStep(current + 1)} disabled={current === total - 1}>
+            Next
+          </button>
+        </div>
+        <button className="course-restart-btn" onClick={restart}>
+          Restart Course
         </button>
-        <button className="course-control-btn" onClick={() => gotoStep(current + 1)} disabled={current === total - 1}>
-          Next
-        </button>
       </div>
-      <button className="course-restart-btn" onClick={restart}>
-        Restart Course
-      </button>
     </div>
   );
 }

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -11,7 +11,7 @@ import handleJoinFree from "./handleJoinFree";
 import handleLeave from "./handleLeave";
 import handleBannerUpload from "./handleBannerUpload";
 import handleFeatureImageUpload from "./handleFeatureImageUpload";
-import handleCourseVideoUpload from "./handleCourseVideoUpload";
+import handleCourseFileUpload from "./handleCourseFileUpload";
 import manageFeatures from "./manageFeatures";
 import manageCourse from "./manageCourse";
 import handleSlugSave from "./handleSlugSave";
@@ -67,7 +67,7 @@ export default function WhopDashboard() {
   // Feature-edit
   const [editFeatures, setEditFeatures] = useState([]);
   const [editCourseSteps, setEditCourseSteps] = useState([
-    { id: 1, title: "", content: "", videoUrl: "", isUploading: false, error: "" }
+    { id: 1, title: "", content: "", fileUrl: "", fileType: "", isUploading: false, error: "" }
   ]);
   const [editModules, setEditModules] = useState({
     chat: false,
@@ -218,8 +218,8 @@ export default function WhopDashboard() {
   const onFeatureImageUpload = async (id, file) => {
     await handleFeatureImageUpload(id, file, setEditFeatures, showNotification);
   };
-  const onCourseVideoUpload = async (id, file) => {
-    await handleCourseVideoUpload(id, file, setEditCourseSteps, showNotification);
+  const onCourseFileUpload = async (id, file) => {
+    await handleCourseFileUpload(id, file, setEditCourseSteps, showNotification);
   };
 
   // 7️⃣ Manage features
@@ -443,7 +443,7 @@ export default function WhopDashboard() {
       addFeature={addFeature}
       editCourseSteps={editCourseSteps}
       handleCourseChange={handleCourseChange}
-      handleVideoUpload={onCourseVideoUpload}
+      handleFileUpload={onCourseFileUpload}
       removeStep={removeStep}
       addStep={addStep}
       campaigns={campaigns}

--- a/src/pages/WhopDashboard/components/CourseSection.jsx
+++ b/src/pages/WhopDashboard/components/CourseSection.jsx
@@ -5,7 +5,7 @@ export default function CourseSection({
   isEditing,
   courseSteps,
   handleCourseChange,
-  handleVideoUpload,
+  handleFileUpload,
   addStep,
   removeStep,
 }) {
@@ -45,13 +45,20 @@ export default function CourseSection({
               />
               <input
                 type="file"
-                accept="video/*"
                 className="course-input"
-                onChange={(e) => handleVideoUpload(step.id, e.target.files[0])}
+                onChange={(e) => handleFileUpload(step.id, e.target.files[0])}
               />
               {step.isUploading && <div className="uploading-msg">Uploading...</div>}
-              {step.videoUrl && !step.isUploading && (
-                <video src={step.videoUrl} controls className="course-video-preview" />
+              {step.fileUrl && !step.isUploading && (
+                step.fileType.startsWith("video/") ? (
+                  <video src={step.fileUrl} controls className="course-video-preview" />
+                ) : step.fileType === "application/pdf" ? (
+                  <embed src={step.fileUrl} type="application/pdf" className="course-pdf-preview" />
+                ) : (
+                  <a href={step.fileUrl} target="_blank" rel="noopener noreferrer" download>
+                    Download File
+                  </a>
+                )
               )}
               {step.error && <div className="course-error">{step.error}</div>}
             </div>
@@ -65,8 +72,16 @@ export default function CourseSection({
           {steps.map((step, idx) => (
             <li key={idx} className="course-step">
               <h3 className="course-step-title">{step.title}</h3>
-              {step.videoUrl && (
-                <video src={step.videoUrl} controls className="course-video" />
+              {step.fileUrl && (
+                step.fileType.startsWith("video/") ? (
+                  <video src={step.fileUrl} controls className="course-video" />
+                ) : step.fileType === "application/pdf" ? (
+                  <embed src={step.fileUrl} type="application/pdf" className="course-pdf" />
+                ) : (
+                  <a href={step.fileUrl} target="_blank" rel="noopener noreferrer" download>
+                    Download File
+                  </a>
+                )
               )}
               <p className="course-step-content">{step.content}</p>
             </li>

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -45,7 +45,7 @@ export default function OwnerMode({
   addFeature,
   editCourseSteps,
   handleCourseChange,
-  handleVideoUpload,
+  handleFileUpload,
   removeStep,
   addStep,
   campaigns,
@@ -172,7 +172,7 @@ export default function OwnerMode({
             isEditing={isEditing}
             courseSteps={editCourseSteps}
             handleCourseChange={handleCourseChange}
-            handleVideoUpload={handleVideoUpload}
+            handleFileUpload={handleFileUpload}
             removeStep={removeStep}
             addStep={addStep}
           />

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -73,11 +73,12 @@ export default async function fetchWhopData(
               id: i + 1,
               title: s.title || "",
               content: s.content || "",
-              videoUrl: s.video_url || "",
+              fileUrl: s.file_url || s.video_url || "",
+              fileType: s.file_type || (s.video_url ? "video/mp4" : ""),
               isUploading: false,
               error: "",
             }))
-          : [{ id: 1, title: "", content: "", videoUrl: "", isUploading: false, error: "" }]
+          : [{ id: 1, title: "", content: "", fileUrl: "", fileType: "", isUploading: false, error: "" }]
       );
 
       setEditLongDescription(data.long_description || "");

--- a/src/pages/WhopDashboard/handleCourseFileUpload.js
+++ b/src/pages/WhopDashboard/handleCourseFileUpload.js
@@ -1,6 +1,6 @@
-// src/pages/WhopDashboard/handleCourseVideoUpload.js
+// src/pages/WhopDashboard/handleCourseFileUpload.js
 
-export default async function handleCourseVideoUpload(
+export default async function handleCourseFileUpload(
   id,
   file,
   setEditCourseSteps,
@@ -16,17 +16,11 @@ export default async function handleCourseVideoUpload(
     );
     return;
   }
-  if (!file.type.startsWith("video/")) {
-    setEditCourseSteps(prev =>
-      (Array.isArray(prev) ? prev : []).map(s =>
-        s.id === id ? { ...s, error: "Please select a video file.", isUploading: false } : s
-      )
-    );
-    return;
-  }
 
   setEditCourseSteps(prev =>
-    (Array.isArray(prev) ? prev : []).map(s => (s.id === id ? { ...s, isUploading: true, error: "" } : s))
+    (Array.isArray(prev) ? prev : []).map(s =>
+      s.id === id ? { ...s, isUploading: true, error: "" } : s
+    )
   );
 
   const formData = new FormData();
@@ -48,20 +42,20 @@ export default async function handleCourseVideoUpload(
     setEditCourseSteps(prev =>
       (Array.isArray(prev) ? prev : []).map(s =>
         s.id === id
-          ? { ...s, videoUrl: data.secure_url, isUploading: false, error: "" }
+          ? { ...s, fileUrl: data.secure_url, fileType: file.type, isUploading: false, error: "" }
           : s
       )
     );
-    showNotification({ type: "success", message: "Video uploaded." });
+    showNotification({ type: "success", message: "File uploaded." });
   } catch (err) {
-    console.error("Course video upload error:", err);
+    console.error("Course file upload error:", err);
     setEditCourseSteps(prev =>
       (Array.isArray(prev) ? prev : []).map(s =>
         s.id === id
-          ? { ...s, videoUrl: "", isUploading: false, error: "Upload failed." }
+          ? { ...s, fileUrl: "", fileType: "", isUploading: false, error: "Upload failed." }
           : s
       )
     );
-    showNotification({ type: "error", message: "Failed to upload video." });
+    showNotification({ type: "error", message: "Failed to upload file." });
   }
 }

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -79,7 +79,8 @@ export default async function handleSaveWhop(
     course_steps:       editCourseSteps.map(s => ({
                           title: s.title.trim(),
                           content: s.content.trim(),
-                          video_url: s.videoUrl || "",
+                          file_url: s.fileUrl || "",
+                          file_type: s.fileType || "",
                         })),
   };
 
@@ -179,7 +180,8 @@ export default async function handleSaveWhop(
               id: i + 1,
               title: s.title || "",
               content: s.content || "",
-              videoUrl: s.video_url || "",
+              fileUrl: s.file_url || s.video_url || "",
+              fileType: s.file_type || (s.video_url ? "video/mp4" : ""),
               isUploading: false,
               error: "",
             }))
@@ -188,7 +190,8 @@ export default async function handleSaveWhop(
                 id: 1,
                 title: "",
                 content: "",
-                videoUrl: "",
+                fileUrl: "",
+                fileType: "",
                 isUploading: false,
                 error: "",
               },

--- a/src/pages/WhopDashboard/manageCourse.js
+++ b/src/pages/WhopDashboard/manageCourse.js
@@ -8,7 +8,7 @@ export default function manageCourse(editCourseSteps, setEditCourseSteps) {
         : 1;
     setEditCourseSteps((prev) => [
       ...(Array.isArray(prev) ? prev : []),
-      { id: newId, title: "", content: "", videoUrl: "", isUploading: false, error: "" },
+      { id: newId, title: "", content: "", fileUrl: "", fileType: "", isUploading: false, error: "" },
     ]);
   };
 

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -443,6 +443,16 @@
       text-align: center;
     }
 
+    .course-viewer {
+      display: flex;
+      gap: var(--spacing-lg);
+    }
+
+    .course-sidebar {
+      width: 16rem;
+      flex-shrink: 0;
+    }
+
     .course-progress-bar {
       width: 100%;
       height: 0.5rem;
@@ -460,12 +470,51 @@
 
     .course-progress-text {
       text-align: center;
-      margin-bottom: var(--spacing-md);
+      margin-bottom: var(--spacing-sm);
       color: var(--text-color);
     }
 
+    .course-steps-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      .course-sidebar-step button {
+        width: 100%;
+        background: none;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--spacing-xs);
+        border-radius: var(--radius-base);
+        cursor: pointer;
+        color: var(--text-color);
+      }
+
+      .course-sidebar-step.active button {
+        background: var(--primary-color);
+        color: #fff;
+      }
+
+      .step-index {
+        font-weight: 600;
+        margin-right: var(--spacing-xs);
+      }
+
+      .step-complete {
+        color: var(--primary-color);
+      }
+    }
+
+    .course-content {
+      flex: 1;
+    }
+
     .course-video,
-    .course-video-preview {
+    .course-video-preview,
+    .course-pdf,
+    .course-pdf-preview {
       width: 100%;
       max-width: 480px;
       margin: var(--spacing-sm) 0;

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -824,7 +824,8 @@
     cursor: pointer;
   }
 
-  .course-video-preview {
+  .course-video-preview,
+  .course-pdf-preview {
     width: 100%;
     max-width: 480px;
   }


### PR DESCRIPTION
## Summary
- overhaul CourseViewer with sidebar progress UI and file rendering
- support arbitrary file uploads when editing course steps
- update course editing components and hooks to work with new file fields
- adjust dashboard styles for new viewer layout

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a9738150832cafce17df93782270