### PR TITLE
Fix owner course editing

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -128,10 +128,10 @@ export default function WhopDashboard() {
       setEditBannerUrl,
       setNewSlugValue,
       setEditFeatures,
-      setEditCourseSteps,
       fetchCampaignsBound,
       setWaitlistEnabled,
       setWaitlistQuestions,
+      setEditCourseSteps,
       setEditLongDescription,
       setEditAboutBio,
       setEditWebsiteUrl,
@@ -139,8 +139,7 @@ export default function WhopDashboard() {
       setEditWhoFor,
       setEditFaq,
       setEditLandingTexts,
-      setEditModules,
-      setEditCourseSteps
+      setEditModules
     );
   }, [initialSlug, location.pathname]);
 
@@ -323,10 +322,10 @@ export default function WhopDashboard() {
         setEditBannerUrl,
         setNewSlugValue,
         setEditFeatures,
-        setEditCourseSteps,
         fetchCampaignsBound,
         setWaitlistEnabled,
         setWaitlistQuestions,
+        setEditCourseSteps,
         setEditLongDescription,
         setEditAboutBio,
         setEditWebsiteUrl,


### PR DESCRIPTION
## Summary
- fix argument order when fetching whop data so owner editing loads existing course steps

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869adc26bb0832c9a3291ff62ba2322