### PR TITLE
Fix paste handling for 2FA code

### DIFF
--- a/src/components/TwoFactorCodeInput.jsx
+++ b/src/components/TwoFactorCodeInput.jsx
@@ -3,6 +3,19 @@ import React, { useRef } from 'react';
 export default function TwoFactorCodeInput({ value, onChange }) {
   const inputRefs = useRef([]);
 
+  const handlePaste = (e, idx) => {
+    e.preventDefault();
+    const paste = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6);
+    if (!paste) return;
+    const codeArr = [...value];
+    for (let i = 0; i < paste.length && idx + i < 6; i++) {
+      codeArr[idx + i] = paste[i];
+    }
+    onChange(codeArr);
+    const nextIndex = Math.min(idx + paste.length, 5);
+    inputRefs.current[nextIndex].focus();
+  };
+
   const handleChange = (e, idx) => {
     const val = e.target.value.replace(/\D/g, '').slice(-1);
     const codeArr = [...value];
@@ -30,6 +43,7 @@ export default function TwoFactorCodeInput({ value, onChange }) {
           value={value[i] || ''}
           onChange={(ev) => handleChange(ev, i)}
           onKeyDown={(ev) => handleKeyDown(ev, i)}
+          onPaste={(ev) => handlePaste(ev, i)}
           ref={(el) => (inputRefs.current[i] = el)}
         />
       ))}


### PR DESCRIPTION
## Summary
- enable pasting an entire 6 digit 2FA code
- focus the correct input after paste

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6869ba1bae48832c88ccfd9dae0c2e72