### PR TITLE
Check email before registration info

### DIFF
--- a/php/check_email.php
+++ b/php/check_email.php
@@ -1,0 +1,45 @@
+<?php
+// check_email.php - check if email exists in users4
+header("Access-Control-Allow-Origin: http://localhost:3000");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Methods: POST, OPTIONS");
+header("Access-Control-Allow-Headers: Content-Type");
+header("Content-Type: application/json; charset=UTF-8");
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+require_once __DIR__ . '/config_login.php';
+
+$inputJSON = file_get_contents('php://input');
+$data = json_decode($inputJSON, true);
+$email = trim($data['email'] ?? '');
+
+if ($email === '') {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Email required']);
+    exit;
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid email']);
+    exit;
+}
+
+$conn = new mysqli($servername, $db_username, $db_password, $database);
+if ($conn->connect_error) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Database connection failed']);
+    exit;
+}
+
+$emailEsc = $conn->real_escape_string($email);
+$res = $conn->query("SELECT id FROM users4 WHERE email='$emailEsc' LIMIT 1");
+$exists = $res && $res->num_rows > 0;
+$conn->close();
+
+echo json_encode(['exists' => $exists]);
+

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -89,6 +89,17 @@ const Register = () => {
     setIdToken(email.trim());
     setMethod('email');
     try {
+      const check = await fetch('https://app.byxbot.com/php/check_email.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      const checkData = await check.json();
+      if (check.ok && checkData.exists) {
+        showNotification({ type: 'error', message: 'Email already registered, please login' });
+        return;
+      }
+
       const res = await fetch('https://app.byxbot.com/php/google_start.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- add PHP API `check_email.php` to verify if an email is already registered
- call this new API in `handleEmail` before sending the 2FA code

## Testing
- `npm ci`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6869c9f20d68832cbe55140633050f95