### PR TITLE
Fix registration flow with verification status

### DIFF
--- a/php/check_email.php
+++ b/php/check_email.php
@@ -37,7 +37,7 @@ if ($conn->connect_error) {
 }
 
 $emailEsc = $conn->real_escape_string($email);
-$res = $conn->query("SELECT id FROM users4 WHERE email='$emailEsc' LIMIT 1");
+$res = $conn->query("SELECT id FROM users4 WHERE email='$emailEsc' AND is_verified=1 LIMIT 1");
 $exists = $res && $res->num_rows > 0;
 $conn->close();
 

--- a/php/google_start.php
+++ b/php/google_start.php
@@ -87,15 +87,15 @@ if ($conn->connect_error) {
 }
 
 $emailEsc = $conn->real_escape_string($email);
-$res = $conn->query("SELECT id, username FROM users4 WHERE email='$emailEsc' LIMIT 1");
+$res = $conn->query("SELECT id, username, is_verified FROM users4 WHERE email='$emailEsc' LIMIT 1");
 if ($res && $res->num_rows > 0) {
-    if ($mode === 'register') {
+    $user = $res->fetch_assoc();
+    if ($mode === 'register' && (int)$user['is_verified'] === 1) {
         http_response_code(400);
         echo json_encode(['status' => 'error', 'message' => 'Email already registered, please login']);
         $conn->close();
         exit;
     }
-    $user = $res->fetch_assoc();
     $userId = (int)$user['id'];
     $username = $user['username'];
 } elseif ($mode === 'register') {
@@ -104,7 +104,7 @@ if ($res && $res->num_rows > 0) {
     $usernameEsc = $conn->real_escape_string($username);
     $dummyPass = bin2hex(random_bytes(16));
     $dummyHash = $conn->real_escape_string(password_hash($dummyPass, PASSWORD_BCRYPT));
-    $insertSql = "INSERT INTO users4 (username, email, password_hash, balance) VALUES ('$usernameEsc', '$emailEsc', '$dummyHash', 0)";
+    $insertSql = "INSERT INTO users4 (username, email, password_hash, balance, is_verified) VALUES ('$usernameEsc', '$emailEsc', '$dummyHash', 0, 0)";
     if ($conn->query($insertSql) !== TRUE) {
         http_response_code(500);
         echo json_encode(['status' => 'error', 'message' => 'Error creating user: ' . $conn->error]);

--- a/php/login.php
+++ b/php/login.php
@@ -42,7 +42,7 @@ if (empty($username) || empty($password)) {
 
 // Find the user by username or email
 $sql = "
-  SELECT id, username, email, password_hash
+  SELECT id, username, email, password_hash, is_verified
   FROM users4
   WHERE username = '$username'
      OR email = '$username'
@@ -63,6 +63,13 @@ $hash = $user['password_hash'];
 if (!password_verify($password, $hash)) {
     http_response_code(401);
     echo json_encode(["status" => "error", "message" => "Invalid login credentials"]);
+    $conn->close();
+    exit;
+}
+
+if ((int)$user['is_verified'] !== 1) {
+    http_response_code(403);
+    echo json_encode(["status" => "error", "message" => "Account not verified"]);
     $conn->close();
     exit;
 }

--- a/php/register.php
+++ b/php/register.php
@@ -99,9 +99,9 @@ if ($resUsername && $resUsername->num_rows > 0) {
 $hashedPassword = password_hash($password, PASSWORD_BCRYPT);
 $insertSql = "
   INSERT INTO users4
-    (username, email, password_hash, balance)
+    (username, email, password_hash, balance, is_verified)
   VALUES
-    ('$username', '$email', '$hashedPassword', 0.00000000)
+    ('$username', '$email', '$hashedPassword', 0.00000000, 1)
 ";
 if ($conn->query($insertSql) !== TRUE) {
     http_response_code(500);

--- a/php/verify_code.php
+++ b/php/verify_code.php
@@ -84,10 +84,14 @@ if (!password_verify($code, $record['code_hash'])) {
 $userId = (int)$record['user_id'];
 $conn->query("DELETE FROM two_factor_codes WHERE id=" . (int)$record['id']);
 
-$userRes = $conn->query("SELECT id, username, email, deposit_address FROM users4 WHERE id=$userId LIMIT 1");
+$userRes = $conn->query("SELECT id, username, email, deposit_address, is_verified FROM users4 WHERE id=$userId LIMIT 1");
 $user = $userRes ? $userRes->fetch_assoc() : null;
 
 if ($user) {
+    if ((int)($user['is_verified'] ?? 0) === 0) {
+        $conn->query("UPDATE users4 SET is_verified=1 WHERE id=$userId");
+        $user['is_verified'] = 1;
+    }
     if ($user['username'] === null || $user['username'] === '') {
         $newUsername = generateUniqueUsername($conn, $user['email']);
         $user['username'] = $newUsername;

--- a/sql/byxdb.sql
+++ b/sql/byxdb.sql
@@ -45,7 +45,8 @@ CREATE TABLE `users4` (
   `deposit_secret` text DEFAULT NULL,
   `date_of_birth` date DEFAULT NULL,
   `country` varchar(100) DEFAULT NULL,
-  `accepted_terms` tinyint(1) NOT NULL DEFAULT 0
+  `accepted_terms` tinyint(1) NOT NULL DEFAULT 0,
+  `is_verified` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/sql/update_users4_is_verified.sql
+++ b/sql/update_users4_is_verified.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users4
+  ADD COLUMN is_verified TINYINT(1) NOT NULL DEFAULT 0 AFTER accepted_terms;


### PR DESCRIPTION
## Summary
- add `is_verified` column to user table and SQL dump
- handle unverified accounts in `check_email.php`, `login.php`, `google_start.php`, `verify_code.php`
- keep regular registration verified by default
- provide schema migration script

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686a41ee77d0832c9898ff62c77a5d9c