### PR TITLE
Improve deposit address checks

### DIFF
--- a/php/deposit.php
+++ b/php/deposit.php
@@ -51,16 +51,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $res = $conn->query($sql);
     if ($res && $res->num_rows > 0) {
         $row = $res->fetch_assoc();
-        // If deposit_address is NULL or empty, return empty string
         $deposit_address = $row["deposit_address"] ?: '';
         $balance = number_format(floatval($row["balance"]), 8, '.', '');
-        echo json_encode([
-            "status" => "success",
-            "data"   => [
-                "deposit_address" => $deposit_address,
-                "balance"         => $balance
-            ]
-        ]);
+        if ($deposit_address === '') {
+            http_response_code(500);
+            echo json_encode([
+                "status"  => "error",
+                "message" => "Deposit address not generated"
+            ]);
+        } else {
+            echo json_encode([
+                "status" => "success",
+                "data"   => [
+                    "deposit_address" => $deposit_address,
+                    "balance"         => $balance
+                ]
+            ]);
+        }
     } else {
         http_response_code(500);
         echo json_encode([

--- a/php/register.php
+++ b/php/register.php
@@ -141,6 +141,30 @@ if ($returnVal !== 0) {
     exit;
 }
 
+// Double-check that the deposit address was actually created
+$resCheck = $conn->query("SELECT deposit_address FROM users4 WHERE id = $newUserId LIMIT 1");
+if (!$resCheck || $resCheck->num_rows === 0) {
+    $conn->query("DELETE FROM users4 WHERE id = $newUserId");
+    http_response_code(500);
+    echo json_encode([
+        "status"  => "error",
+        "message" => "Deposit address not generated"
+    ]);
+    $conn->close();
+    exit;
+}
+$rowCheck = $resCheck->fetch_assoc();
+if (!$rowCheck['deposit_address']) {
+    $conn->query("DELETE FROM users4 WHERE id = $newUserId");
+    http_response_code(500);
+    echo json_encode([
+        "status"  => "error",
+        "message" => "Deposit address not generated"
+    ]);
+    $conn->close();
+    exit;
+}
+
 // 10) All good — return success
 http_response_code(201);
 echo json_encode([

--- a/php/verify_code.php
+++ b/php/verify_code.php
@@ -109,6 +109,20 @@ if ($user) {
         $scriptPath = __DIR__ . '/../solana-monitor/setup_deposit_addresses.js';
         $cmd = escapeshellcmd("$nodePath $scriptPath $userId");
         exec($cmd . " 2>&1", $out, $ret);
+        if ($ret === 0) {
+            $resCheck = $conn->query("SELECT deposit_address FROM users4 WHERE id = $userId LIMIT 1");
+            if (!$resCheck || $resCheck->num_rows === 0 || !$resCheck->fetch_assoc()['deposit_address']) {
+                http_response_code(500);
+                echo json_encode(['status' => 'error', 'message' => 'Deposit address not generated']);
+                $conn->close();
+                exit;
+            }
+        } else {
+            http_response_code(500);
+            echo json_encode(['status' => 'error', 'message' => 'Error generating deposit address: ' . implode("\n", $out)]);
+            $conn->close();
+            exit;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add checks after running `setup_deposit_addresses.js` in register/login flows
- return an error if a deposit address wasn't created
- surface missing deposit address error in deposit API

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a62f12234832c9a4be700169d1e15