### PR TITLE
Fix PDF viewer and course layout

### DIFF
--- a/src/components/CourseViewer.jsx
+++ b/src/components/CourseViewer.jsx
@@ -69,7 +69,12 @@ export default function CourseViewer({ steps = [], initialCompleted = [], whopId
           (step.file_type || "").startsWith("video/") || step.video_url ? (
             <video src={step.file_url || step.video_url} controls className="course-video" />
           ) : step.file_type === "application/pdf" ? (
-            <embed src={step.file_url} type="application/pdf" className="course-pdf" />
+            <iframe
+              src={step.file_url}
+              title="Course PDF"
+              className="course-pdf"
+              frameBorder="0"
+            />
           ) : (
             <a href={step.file_url} target="_blank" rel="noopener noreferrer" download>
               Download File

--- a/src/pages/WhopDashboard/components/CourseSection.jsx
+++ b/src/pages/WhopDashboard/components/CourseSection.jsx
@@ -53,7 +53,12 @@ export default function CourseSection({
                 step.fileType.startsWith("video/") ? (
                   <video src={step.fileUrl} controls className="course-video-preview" />
                 ) : step.fileType === "application/pdf" ? (
-                  <embed src={step.fileUrl} type="application/pdf" className="course-pdf-preview" />
+                  <iframe
+                    src={step.fileUrl}
+                    title={`Course Step ${idx + 1} PDF`}
+                    className="course-pdf-preview"
+                    frameBorder="0"
+                  />
                 ) : (
                   <a href={step.fileUrl} target="_blank" rel="noopener noreferrer" download>
                     Download File
@@ -76,7 +81,12 @@ export default function CourseSection({
                 step.fileType.startsWith("video/") ? (
                   <video src={step.fileUrl} controls className="course-video" />
                 ) : step.fileType === "application/pdf" ? (
-                  <embed src={step.fileUrl} type="application/pdf" className="course-pdf" />
+                  <iframe
+                    src={step.fileUrl}
+                    title={`Course Step ${idx + 1} PDF`}
+                    className="course-pdf"
+                    frameBorder="0"
+                  />
                 ) : (
                   <a href={step.fileUrl} target="_blank" rel="noopener noreferrer" download>
                     Download File

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -446,6 +446,7 @@
     .course-viewer {
       display: flex;
       gap: var(--spacing-lg);
+      align-items: flex-start;
     }
 
     .course-sidebar {
@@ -482,19 +483,24 @@
       .course-sidebar-step button {
         width: 100%;
         background: none;
-        border: none;
+        border: 1px solid var(--border-color);
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: var(--spacing-xs);
+        padding: var(--spacing-xs) var(--spacing-sm);
         border-radius: var(--radius-base);
         cursor: pointer;
         color: var(--text-color);
+        transition: background var(--transition);
       }
 
       .course-sidebar-step.active button {
         background: var(--primary-color);
         color: #fff;
+      }
+
+      .course-sidebar-step button:hover {
+        background: var(--border-color);
       }
 
       .step-index {
@@ -512,12 +518,18 @@
     }
 
     .course-video,
-    .course-video-preview,
-    .course-pdf,
-    .course-pdf-preview {
+    .course-video-preview {
       width: 100%;
       max-width: 480px;
       margin: var(--spacing-sm) 0;
+    }
+
+    .course-pdf,
+    .course-pdf-preview {
+      width: 100%;
+      height: 600px;
+      margin: var(--spacing-sm) 0;
+      border: 1px solid var(--border-color);
     }
 
     .course-complete-btn {
@@ -576,5 +588,14 @@
   }
   .member-main {
     margin-top: var(--spacing-lg);
+  }
+
+  .course-viewer {
+    flex-direction: column;
+  }
+
+  .course-sidebar {
+    width: 100%;
+    margin-bottom: var(--spacing-md);
   }
 }

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -824,10 +824,15 @@
     cursor: pointer;
   }
 
-  .course-video-preview,
-  .course-pdf-preview {
+  .course-video-preview {
     width: 100%;
     max-width: 480px;
+  }
+
+  .course-pdf-preview {
+    width: 100%;
+    height: 300px;
+    border: 1px solid var(--border-color);
   }
 
   .course-error {


### PR DESCRIPTION
## Summary
- render course PDFs in iframes so they display correctly
- refine course viewer layout and responsiveness
- style course PDF and step list for better appearance

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686bf5f0dd68832cbf8c26fe07346336