### PR TITLE
Fix PDF course uploads

### DIFF
--- a/src/pages/WhopDashboard/handleCourseFileUpload.js
+++ b/src/pages/WhopDashboard/handleCourseFileUpload.js
@@ -29,7 +29,7 @@ export default async function handleCourseFileUpload(
 
   try {
     const res = await fetch(
-      `https://api.cloudinary.com/v1_1/dv6igcvz8/upload`,
+      `https://api.cloudinary.com/v1_1/dv6igcvz8/auto/upload`,
       {
         method: "POST",
         body: formData,


### PR DESCRIPTION
## Summary
- use Cloudinary auto upload endpoint for course step files

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686bfdaf4900832c83d47dfaa17a06f6