### PR TITLE
Fix course progress reset on tab change

### DIFF
--- a/src/components/CourseViewer.jsx
+++ b/src/components/CourseViewer.jsx
@@ -1,7 +1,12 @@
 import React, { useState, useEffect } from "react";
 import "../styles/whop-dashboard/_member.scss";
 
-export default function CourseViewer({ steps = [], initialCompleted = [], whopId }) {
+export default function CourseViewer({
+  steps = [],
+  initialCompleted = [],
+  whopId,
+  onProgressChange,
+}) {
   const [current, setCurrent] = useState(0);
   const [completed, setCompleted] = useState(initialCompleted);
 
@@ -18,6 +23,11 @@ export default function CourseViewer({ steps = [], initialCompleted = [], whopId
 
   async function save(newCompleted) {
     setCompleted(newCompleted);
+    if (typeof onProgressChange === "function") {
+      try {
+        onProgressChange(newCompleted);
+      } catch {}
+    }
     try {
       await fetch("https://app.byxbot.com/php/save_course_progress.php", {
         method: "POST",

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -376,6 +376,7 @@ export default function WhopDashboard() {
         setActiveTab={setActiveTab}
         memberLoading={memberLoading}
         handleLeave={onLeave}
+        setWhopData={setWhopData}
         onBack={() => setViewAsMemberMode(false)}
       />
     );
@@ -393,6 +394,7 @@ export default function WhopDashboard() {
         setActiveTab={setActiveTab}
         memberLoading={memberLoading}
         handleLeave={onLeave}
+        setWhopData={setWhopData}
       />
     );
   }

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -13,6 +13,7 @@ export default function MemberMain({
   campaignsLoading,
   campaignsError,
   onSelectCampaign,
+  setWhopData,
 }) {
   return (
     <div className="member-main">
@@ -191,6 +192,10 @@ export default function MemberMain({
             steps={whopData.course_steps || []}
             initialCompleted={whopData.course_progress || []}
             whopId={whopData.id}
+            onProgressChange={(arr) =>
+              typeof setWhopData === "function" &&
+              setWhopData((prev) => ({ ...prev, course_progress: arr }))
+            }
           />
         </div>
       )}

--- a/src/pages/WhopDashboard/components/MemberMode.jsx
+++ b/src/pages/WhopDashboard/components/MemberMode.jsx
@@ -14,6 +14,7 @@ export default function MemberMode({
   setActiveTab,
   memberLoading,
   handleLeave,
+  setWhopData,
 }) {
   // State for the selected campaign (when the user clicks in the "Earn" tab)
   const [selectedCampaign, setSelectedCampaign] = useState(null);
@@ -63,6 +64,7 @@ export default function MemberMode({
         campaignsLoading={campaignsLoading}
         campaignsError={campaignsError}
         onSelectCampaign={setSelectedCampaign}
+        setWhopData={setWhopData}
       />
     </div>
   );

--- a/src/pages/WhopDashboard/components/ViewAsMember.jsx
+++ b/src/pages/WhopDashboard/components/ViewAsMember.jsx
@@ -25,7 +25,8 @@ export default function ViewAsMember({
   setActiveTab,
   memberLoading,
   handleLeave,
-  onBack
+  onBack,
+  setWhopData
 }) {
   return (
     <>
@@ -51,6 +52,7 @@ export default function ViewAsMember({
         campaigns={campaigns}
         campaignsLoading={campaignsLoading}
         campaignsError={campaignsError}
+        setWhopData={setWhopData}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- update `CourseViewer` to report progress changes
- use new prop in `MemberMain` to update `whopData.course_progress`
- plumb `setWhopData` through member views

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c1326794c832c97f2da256a6225a0