### PR TITLE
Add placeholder Discord Access module

### DIFF
--- a/sql/update_whops_add_discord_access_module.sql
+++ b/sql/update_whops_add_discord_access_module.sql
@@ -1,0 +1,12 @@
+-- Add discord_access property to modules JSON
+UPDATE whops
+SET modules = CASE
+    WHEN modules IS NULL OR modules = '' THEN '{"discord_access":false}'
+    WHEN JSON_VALID(modules) THEN
+        CASE
+            WHEN JSON_EXTRACT(modules, '$.discord_access') IS NULL THEN
+                JSON_INSERT(modules, '$.discord_access', false)
+            ELSE modules
+        END
+    ELSE modules
+END;

--- a/src/pages/Setup.jsx
+++ b/src/pages/Setup.jsx
@@ -55,6 +55,7 @@ export default function Setup() {
       chat: false,
       earn: false,
       discord: false,
+      discord_access: false,
       course: false,
       text: true,
     }
@@ -363,11 +364,12 @@ export default function Setup() {
         <div className="setup-section">
           <h2>Enable Modules</h2>
           {[
-            ["chat", "Chat"],
-            ["earn", "Earn"],
-            ["discord", "Discord Access"],
-            ["course", "Course"],
-            ["text", "Text Features"],
+          ["chat", "Chat"],
+          ["earn", "Earn"],
+          ["discord", "Discord"],
+          ["discord_access", "Discord Access"],
+          ["course", "Course"],
+          ["text", "Text Features"],
           ].map(([key, label]) => (
             <label key={key} className="setup-checkbox-label">
               <input

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -73,6 +73,7 @@ export default function WhopDashboard() {
     chat: false,
     earn: false,
     discord: false,
+    discord_access: false,
     course: false,
     text: true,
   });

--- a/src/pages/WhopDashboard/components/OwnerModules.jsx
+++ b/src/pages/WhopDashboard/components/OwnerModules.jsx
@@ -8,7 +8,8 @@ export default function OwnerModules({ editModules, setEditModules, isEditing })
   const labels = {
     chat: "Chat",
     earn: "Earn",
-    discord: "Discord Access",
+    discord: "Discord",
+    discord_access: "Discord Access",
     course: "Course",
     text: "Text Features",
   };

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -115,6 +115,7 @@ export default async function fetchWhopData(
           chat: false,
           earn: false,
           discord: false,
+          discord_access: false,
           course: false,
           text: true,
         }

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -158,6 +158,7 @@ export default async function handleSaveWhop(
           chat: false,
           earn: false,
           discord: false,
+          discord_access: false,
           course: false,
           text: true,
         }


### PR DESCRIPTION
## Summary
- include `discord_access` feature flag in setup and owner dashboard
- show toggle for it in owner modules
- provide default handling when fetching/creating whops
- add SQL script to populate the new flag

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686c1b84bbe4832cba167988cf0ae967