### PR TITLE
Add Discord access integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Discord Access Bot
+
+The `discord-bot` folder contains a minimal bot that links a Discord server with the platform. Install dependencies and configure environment variables using `.env` or `.env.example`.
+
+Run the bot with:
+
+```bash
+cd discord-bot
+npm install
+node bot.js
+```
+
+Invite the bot to your server and execute `/setup` to receive a verification code.

--- a/discord-bot/.env.example
+++ b/discord-bot/.env.example
@@ -1,0 +1,7 @@
+DISCORD_TOKEN=
+CLIENT_ID=
+GUILD_ID=
+DB_HOST=localhost
+DB_USER=dbadmin
+DB_PASS=3otwj3zR6EI
+DB_NAME=byx

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,0 +1,26 @@
+# Discord Access Bot
+
+This bot links a Discord server with the Whop platform.
+
+## Setup
+1. Install dependencies:
+```bash
+npm install
+```
+2. Create a `.env` file with:
+```
+DISCORD_TOKEN=your_bot_token
+CLIENT_ID=your_application_id
+GUILD_ID=optional_guild_id
+DB_HOST=localhost
+DB_USER=dbadmin
+DB_PASS=3otwj3zR6EI
+DB_NAME=byx
+```
+`GUILD_ID` can be omitted to register slash commands globally.
+3. Run the bot:
+```bash
+node bot.js
+```
+
+The bot exposes a single `/setup` command. Use it without arguments to receive a six digit code in a DM. Run the command again with the code to link the server.

--- a/discord-bot/bot.js
+++ b/discord-bot/bot.js
@@ -1,0 +1,119 @@
+import { Client, GatewayIntentBits, Partials, REST, Routes, SlashCommandBuilder } from 'discord.js';
+import mysql from 'mysql2/promise';
+import 'dotenv/config';
+
+const TOKEN = process.env.DISCORD_TOKEN;
+const CLIENT_ID = process.env.CLIENT_ID;
+const GUILD_ID = process.env.GUILD_ID || null;
+
+const DB_CONFIG = {
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'dbadmin',
+  password: process.env.DB_PASS || '3otwj3zR6EI',
+  database: process.env.DB_NAME || 'byx',
+  charset: 'utf8mb4',
+};
+
+const client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers],
+  partials: [Partials.Channel],
+});
+
+const rest = new REST({ version: '10' }).setToken(TOKEN);
+
+const setupCommand = new SlashCommandBuilder()
+  .setName('setup')
+  .setDescription('Link this Discord server with Whop')
+  .addStringOption(opt =>
+    opt.setName('code').setDescription('6 digit code').setRequired(false)
+  );
+
+async function registerCommands() {
+  const commands = [setupCommand.toJSON()];
+  if (GUILD_ID) {
+    await rest.put(Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID), { body: commands });
+  } else {
+    await rest.put(Routes.applicationCommands(CLIENT_ID), { body: commands });
+  }
+  console.log('Commands registered');
+}
+
+const pendingCodes = new Map(); // userId -> code
+
+client.on('interactionCreate', async interaction => {
+  if (!interaction.isChatInputCommand() || interaction.commandName !== 'setup') return;
+  const codeArg = interaction.options.getString('code');
+
+  if (!codeArg) {
+    const code = Math.floor(100000 + Math.random() * 900000).toString();
+    pendingCodes.set(interaction.user.id, code);
+    try {
+      await interaction.user.send(`Your verification code: **${code}**`);
+      await interaction.reply({ content: 'Check your DMs and run /setup again with the code.', ephemeral: true });
+    } catch (e) {
+      await interaction.reply({ content: 'I cannot DM you. Please enable DMs and try again.', ephemeral: true });
+    }
+    return;
+  }
+
+  const expected = pendingCodes.get(interaction.user.id);
+  if (!expected || expected !== codeArg) {
+    await interaction.reply({ content: 'Invalid or expired code.', ephemeral: true });
+    return;
+  }
+
+  pendingCodes.delete(interaction.user.id);
+
+  const guildId = interaction.guildId;
+  if (!guildId) {
+    await interaction.reply({ content: 'This command must be used in a server.', ephemeral: true });
+    return;
+  }
+
+  try {
+    const conn = await mysql.createConnection(DB_CONFIG);
+    await conn.execute(
+      'REPLACE INTO discord_servers (guild_id, owner_discord_id) VALUES (?, ?)',
+      [guildId, interaction.user.id]
+    );
+    await conn.end();
+    await interaction.reply({ content: 'Server linked successfully!', ephemeral: true });
+  } catch (err) {
+    console.error('DB error', err);
+    await interaction.reply({ content: 'Database error.', ephemeral: true });
+  }
+});
+
+client.once('ready', () => {
+  console.log(`Logged in as ${client.user.tag}`);
+});
+
+registerCommands()
+  .then(() => client.login(TOKEN))
+  .catch(console.error);
+
+// Periodic membership check every 12 hours
+setInterval(async () => {
+  let conn;
+  try {
+    conn = await mysql.createConnection(DB_CONFIG);
+    const [rows] = await conn.execute('SELECT guild_id, discord_id FROM discord_members');
+    for (const row of rows) {
+      const guild = await client.guilds.fetch(row.guild_id).catch(() => null);
+      if (!guild) continue;
+      const member = await guild.members.fetch(row.discord_id).catch(() => null);
+      if (!member) continue;
+      const [[statusRow]] = await conn.execute(
+        'SELECT active FROM whop_members WHERE discord_id=?',
+        [row.discord_id]
+      );
+      if (!statusRow || !statusRow.active) {
+        await member.kick('Inactive membership').catch(() => null);
+      }
+    }
+  } catch (err) {
+    console.error('Periodic check failed', err);
+  } finally {
+    if (conn) await conn.end();
+  }
+}, 12 * 60 * 60 * 1000);

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "discord-access-bot",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "discord.js": "^14.11.0",
+    "mysql2": "^3.3.0"
+  }
+}

--- a/php/discord_link.php
+++ b/php/discord_link.php
@@ -1,0 +1,77 @@
+<?php
+// discord_link.php - manage linking of a Discord server
+
+header("Access-Control-Allow-Origin: http://localhost:3000");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+header("Access-Control-Allow-Headers: Content-Type");
+header("Content-Type: application/json; charset=UTF-8");
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+require_once __DIR__ . '/session_init.php';
+$user_id = $_SESSION['user_id'] ?? null;
+if (!$user_id) {
+    http_response_code(401);
+    echo json_encode(["status" => "error", "message" => "Unauthorized"]);
+    exit;
+}
+
+require_once __DIR__ . '/config_login.php';
+
+try {
+    $pdo = new PDO(
+        "mysql:host=$servername;dbname=$database;charset=utf8mb4",
+        $db_username,
+        $db_password,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(["status" => "error", "message" => "Database connection error"]);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'POST') {
+    $input = json_decode(file_get_contents('php://input'), true);
+    $action = $input['action'] ?? '';
+    if ($action === 'request_code') {
+        $code = random_int(100000, 999999);
+        $_SESSION['discord_setup_code'] = $code;
+        echo json_encode(['status' => 'success', 'code' => $code]);
+        exit;
+    }
+    if ($action === 'confirm') {
+        $guildId = $input['guild_id'] ?? '';
+        $code = $input['code'] ?? '';
+        if ($code != ($_SESSION['discord_setup_code'] ?? '')) {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'message' => 'Invalid code']);
+            exit;
+        }
+        unset($_SESSION['discord_setup_code']);
+        $stmt = $pdo->prepare('REPLACE INTO discord_servers (guild_id, owner_discord_id) VALUES (:gid, :owner)');
+        $stmt->execute(['gid' => $guildId, 'owner' => $_SESSION['discord_id'] ?? '']);
+        echo json_encode(['status' => 'success']);
+        exit;
+    }
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Unknown action']);
+    exit;
+}
+
+if ($method === 'GET') {
+    $stmt = $pdo->prepare('SELECT guild_id FROM discord_servers WHERE owner_discord_id=:owner LIMIT 1');
+    $stmt->execute(['owner' => $_SESSION['discord_id'] ?? '']);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    echo json_encode(['status' => 'success', 'data' => $row]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['status' => 'error', 'message' => 'Method not allowed']);

--- a/sql/create_discord_access_tables.sql
+++ b/sql/create_discord_access_tables.sql
@@ -1,0 +1,14 @@
+-- Table storing linked Discord servers
+CREATE TABLE IF NOT EXISTS discord_servers (
+  guild_id VARCHAR(30) PRIMARY KEY,
+  owner_discord_id VARCHAR(30) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Members joined via Discord
+CREATE TABLE IF NOT EXISTS discord_members (
+  guild_id VARCHAR(30) NOT NULL,
+  discord_id VARCHAR(30) NOT NULL,
+  joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id, discord_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,8 @@ const Profile              = lazy(() => import("./pages/Profile"));
 const Balances             = lazy(() => import("./pages/Balances"));
 const Memberships          = lazy(() => import("./pages/Memberships"));
 const Payments             = lazy(() => import("./pages/Payments"));
+const DiscordAccess        = lazy(() => import("./pages/DiscordAccess"));
+const DiscordAccessSetup   = lazy(() => import("./pages/DiscordAccessSetup"));
 
 const App = () => {
   return (
@@ -236,6 +238,38 @@ const App = () => {
                   <Sidebar />
                   <main className="main-content">
                     <Payments />
+                  </main>
+                  <BottomBar />
+                </div>
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Discord Access */}
+          <Route
+            path="/discord-access"
+            element={
+              <ProtectedRoute>
+                <div className="app-container">
+                  <Sidebar />
+                  <main className="main-content">
+                    <DiscordAccess />
+                  </main>
+                  <BottomBar />
+                </div>
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Discord Access Setup */}
+          <Route
+            path="/dashboard/discord-setup"
+            element={
+              <ProtectedRoute>
+                <div className="app-container">
+                  <Sidebar />
+                  <main className="main-content">
+                    <DiscordAccessSetup />
                   </main>
                   <BottomBar />
                 </div>

--- a/src/pages/DiscordAccess.jsx
+++ b/src/pages/DiscordAccess.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useNotifications } from "../components/NotificationProvider";
+
+export default function DiscordAccess() {
+  const { showNotification } = useNotifications();
+
+  const handleConnect = async () => {
+    try {
+      showNotification({ type: "info", message: "Redirecting to Discord..." });
+      window.location.href = "https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=identify+guilds.join";
+    } catch (err) {
+      showNotification({ type: "error", message: "Failed to start Discord OAuth" });
+    }
+  };
+
+  return (
+    <div className="discord-access-page">
+      <h2>Discord Access</h2>
+      <p>Connect your Discord account to join the server.</p>
+      <button className="primary-btn" onClick={handleConnect}>
+        Get Access
+      </button>
+    </div>
+  );
+}

--- a/src/pages/DiscordAccessSetup.jsx
+++ b/src/pages/DiscordAccessSetup.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function DiscordAccessSetup() {
+  return (
+    <div className="discord-setup-page">
+      <h2>Discord Access Setup</h2>
+      <ol>
+        <li>Invite the bot to your Discord server using the link from your dashboard.</li>
+        <li>Run the `/setup` command in your server.</li>
+        <li>The bot will DM you a six digit code. Run `/setup <code>` to finish.</li>
+      </ol>
+      <p>Once completed, this page will show your connected server.</p>
+    </div>
+  );
+}

--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -184,6 +184,17 @@ export default function MemberMain({
         </div>
       )}
 
+      {/* DISCORD */}
+      {activeTab === "Discord" && whopData.modules?.discord_access && (
+        <div className="member-tab-content">
+          <h3 className="member-subtitle">Discord Access</h3>
+          <p className="member-text">
+            Link your Discord account to join the server.
+          </p>
+          <a className="primary-btn" href="/discord-access">Get Access</a>
+        </div>
+      )}
+
       {/* COURSE */}
       {activeTab === "Course" && whopData.modules?.course && (
         <div className="member-tab-content">

--- a/src/pages/WhopDashboard/components/MemberSidebar.jsx
+++ b/src/pages/WhopDashboard/components/MemberSidebar.jsx
@@ -7,6 +7,7 @@ import {
   FaComments,
   FaDollarSign,
   FaTools,
+  FaDiscord,
   FaSignOutAlt
 } from "react-icons/fa";
 import "../../../styles/whop-dashboard/_member.scss";
@@ -58,6 +59,14 @@ export default function MemberSidebar({
             onClick={() => setActiveTab("Earn")}
           >
             <FaDollarSign /> Earn
+          </button>
+        )}
+        {whopData.modules?.discord_access && (
+          <button
+            className={`nav-button ${activeTab === "Discord" ? "active" : ""}`}
+            onClick={() => setActiveTab("Discord")}
+          >
+            <FaDiscord /> Discord
           </button>
         )}
         {whopData.modules?.course && (


### PR DESCRIPTION
## Summary
- add optional Discord access module in dashboard
- create pages for Discord access and setup
- update member sidebar and main view when module is enabled
- add Discord bot implementation for managing server access
- document bot usage in README
- add SQL schema and backend endpoint

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686c26784c98832c9d8e18e9bed4742b