### PR TITLE
Add Discord access section and remove old module

### DIFF
--- a/src/pages/Setup.jsx
+++ b/src/pages/Setup.jsx
@@ -54,7 +54,6 @@ export default function Setup() {
     cookieData.modules || {
       chat: false,
       earn: false,
-      discord: false,
       discord_access: false,
       course: false,
       text: true,
@@ -366,7 +365,6 @@ export default function Setup() {
           {[
           ["chat", "Chat"],
           ["earn", "Earn"],
-          ["discord", "Discord"],
           ["discord_access", "Discord Access"],
           ["course", "Course"],
           ["text", "Text Features"],

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -72,7 +72,6 @@ export default function WhopDashboard() {
   const [editModules, setEditModules] = useState({
     chat: false,
     earn: false,
-    discord: false,
     discord_access: false,
     course: false,
     text: true,

--- a/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
+++ b/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+
+export default function DiscordSetupSection({ isEditing }) {
+  const [guildId, setGuildId] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("https://app.byxbot.com/php/discord_link.php", {
+      method: "GET",
+      credentials: "include",
+    })
+      .then(res => res.json())
+      .then(json => {
+        if (json.status === "success" && json.data && json.data.guild_id) {
+          setGuildId(json.data.guild_id);
+        }
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const inviteUrl =
+    "https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=8&scope=bot+applications.commands";
+
+  return (
+    <div className="discord-setup-section">
+      <h2 className="discord-setup-title">Discord Access Setup</h2>
+      {loading ? (
+        <p>Loading...</p>
+      ) : guildId ? (
+        <p>Connected server ID: {guildId}</p>
+      ) : isEditing ? (
+        <ol>
+          <li>
+            Invite the bot to your Discord server using
+            {" "}
+            <a href={inviteUrl} target="_blank" rel="noopener noreferrer">
+              this link
+            </a>
+            .
+          </li>
+          <li>Run the <code>/setup</code> command in your server.</li>
+          <li>
+            The bot will DM you a six digit code. Run
+            <code> /setup &lt;code&gt;</code> to finish.
+          </li>
+        </ol>
+      ) : (
+        <p>No Discord server connected.</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -9,6 +9,7 @@ import OwnerSlugPrice from "./OwnerSlugPrice";
 import OwnerActionButtons from "./OwnerActionButtons";
 import FeaturesSection from "./FeaturesSection";
 import CourseSection from "./CourseSection";
+import DiscordSetupSection from "./DiscordSetupSection";
 import CampaignsSection from "./CampaignsSection";
 import MembersSection from "./MembersSection";
 import CampaignModal from "./CampaignModal";
@@ -167,6 +168,10 @@ export default function OwnerMode({
             removeFeature={removeFeature}
             addFeature={addFeature}
           />
+        )}
+
+        {editModules.discord_access && (
+          <DiscordSetupSection isEditing={isEditing} />
         )}
 
         {editModules.course && (

--- a/src/pages/WhopDashboard/components/OwnerModules.jsx
+++ b/src/pages/WhopDashboard/components/OwnerModules.jsx
@@ -8,7 +8,6 @@ export default function OwnerModules({ editModules, setEditModules, isEditing })
   const labels = {
     chat: "Chat",
     earn: "Earn",
-    discord: "Discord",
     discord_access: "Discord Access",
     course: "Course",
     text: "Text Features",

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -114,7 +114,6 @@ export default async function fetchWhopData(
         data.modules || {
           chat: false,
           earn: false,
-          discord: false,
           discord_access: false,
           course: false,
           text: true,

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -157,7 +157,6 @@ export default async function handleSaveWhop(
         data.modules || {
           chat: false,
           earn: false,
-          discord: false,
           discord_access: false,
           course: false,
           text: true,


### PR DESCRIPTION
## Summary
- add Discord access setup section in owner dashboard
- remove duplicate `discord` module option
- show Discord setup instructions when `discord_access` module is enabled

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_686c2af7c34c832cb325883589f364bb