### PR TITLE
Fix client id link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_DISCORD_CLIENT_ID=your_application_id

--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ node bot.js
 ```
 
 Invite the bot to your server and execute `/setup` to receive a verification code.
+
+## Client Environment Variables
+
+The React frontend uses `REACT_APP_DISCORD_CLIENT_ID` to generate Discord
+authorization links. Create an `.env` file in the project root containing:
+
+```
+REACT_APP_DISCORD_CLIENT_ID=your_application_id
+```
+
+Restart the development server after adding the file so the variable is picked
+up.

--- a/src/pages/DiscordAccess.jsx
+++ b/src/pages/DiscordAccess.jsx
@@ -7,7 +7,8 @@ export default function DiscordAccess() {
   const handleConnect = async () => {
     try {
       showNotification({ type: "info", message: "Redirecting to Discord..." });
-      window.location.href = "https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=identify+guilds.join";
+      const clientId = process.env.REACT_APP_DISCORD_CLIENT_ID;
+      window.location.href = `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=identify+guilds.join`;
     } catch (err) {
       showNotification({ type: "error", message: "Failed to start Discord OAuth" });
     }

--- a/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
+++ b/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
@@ -20,7 +20,7 @@ export default function DiscordSetupSection({ isEditing }) {
   }, []);
 
   const inviteUrl =
-    "https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=8&scope=bot+applications.commands";
+    `https://discord.com/oauth2/authorize?client_id=${process.env.REACT_APP_DISCORD_CLIENT_ID}&permissions=8&scope=bot+applications.commands`;
 
   return (
     <div className="discord-setup-section">


### PR DESCRIPTION
## Summary
- pull Discord OAuth client id from `REACT_APP_DISCORD_CLIENT_ID`
- show environment variable setup in README
- add `.env.example`

## Testing
- `npm install`
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_686c32ad0bf4832cbb1d899042e304eb