### PR TITLE
Fix Discord server retrieval

### DIFF
--- a/php/discord_link.php
+++ b/php/discord_link.php
@@ -66,8 +66,13 @@ if ($method === 'POST') {
 }
 
 if ($method === 'GET') {
-    $stmt = $pdo->prepare('SELECT guild_id FROM discord_servers WHERE owner_discord_id=:owner LIMIT 1');
-    $stmt->execute(['owner' => $_SESSION['discord_id'] ?? '']);
+    $discordId = $_SESSION['discord_id'] ?? null;
+    if ($discordId) {
+        $stmt = $pdo->prepare('SELECT guild_id FROM discord_servers WHERE owner_discord_id = :owner LIMIT 1');
+        $stmt->execute(['owner' => $discordId]);
+    } else {
+        $stmt = $pdo->query('SELECT guild_id FROM discord_servers ORDER BY created_at DESC LIMIT 1');
+    }
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     echo json_encode(['status' => 'success', 'data' => $row]);
     exit;


### PR DESCRIPTION
## Summary
- ensure Discord setup page finds a linked server even when no Discord session ID exists

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d2f0819bc832c89ef5f66d3cc40fd