### PR TITLE
Add Discord OAuth instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,21 @@ Invite the bot to your server and execute `/setup` to receive a verification cod
 
 The React frontend now contains the Discord application ID directly in the source
 code. No additional environment variables are required to run the client.
+
+## Discord OAuth Setup
+
+The Discord OAuth flow expects the following redirect URL:
+
+```
+https://<your-domain>/discord-access
+```
+
+Add this exact URL to the **Redirects** list in your Discord application's OAuth2 settings. If the URL is missing, Discord will display an `Invalid OAuth2 redirect_uri` error.
+
+For local development you may also include:
+
+```
+http://localhost:3000/discord-access
+```
+
+Once configured, clicking **Get Access** will redirect to Discord and then back to `/discord-access` with a `code` query parameter.

--- a/src/pages/DiscordAccess.jsx
+++ b/src/pages/DiscordAccess.jsx
@@ -1,9 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useNotifications } from "../components/NotificationProvider";
 
 export default function DiscordAccess() {
   const { showNotification } = useNotifications();
   const DISCORD_CLIENT_ID = "1391881188901388348";
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
+    if (error) {
+      showNotification({ type: "error", message: error });
+      return;
+    }
+    if (params.get("code")) {
+      showNotification({ type: "success", message: "Discord authorization successful." });
+    }
+  }, [showNotification]);
 
   const handleConnect = async () => {
     try {


### PR DESCRIPTION
## Summary
- add instructions for configuring Discord OAuth redirect
- show an error or success message when returning from Discord

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d35c060c0832cba3d29e078b8b963