### PR TITLE
Fix Discord rejoin flow

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -16,6 +16,7 @@ export default function MemberMain({
   setWhopData,
 }) {
   const [discordLinked, setDiscordLinked] = useState(false);
+  const [discordMember, setDiscordMember] = useState(false);
   const [guildId, setGuildId] = useState("");
 
   useEffect(() => {
@@ -41,8 +42,13 @@ export default function MemberMain({
           }
         );
         const json = await res.json();
-        if (json.status === "success" && json.data?.guild_id) {
-          setGuildId(json.data.guild_id);
+        if (json.status === "success") {
+          if (json.data?.guild_id) {
+            setGuildId(json.data.guild_id);
+          }
+          if (typeof json.data?.is_member === "boolean") {
+            setDiscordMember(json.data.is_member);
+          }
         }
       } catch {}
     }
@@ -222,11 +228,11 @@ export default function MemberMain({
         <div className="member-tab-content">
           <h3 className="member-subtitle">Discord Access</h3>
           <p className="member-text">
-            {discordLinked
+            {discordLinked && discordMember
               ? "Discord access active."
               : "Link your Discord account to join the server."}
           </p>
-          {discordLinked ? (
+          {discordLinked && discordMember ? (
             <a
               className="primary-btn"
               href={


### PR DESCRIPTION
## Summary
- add member check to `discord_link.php`
- surface membership state in dashboard

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686d75d545dc832cbc8d5a2bd0a329b3