### PR TITLE
Fix Discord join button rejoin via OAuth

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -235,13 +235,7 @@ export default function MemberMain({
           {discordLinked && discordMember ? (
             <a
               className="primary-btn"
-              href={
-                guildId
-                  ? `https://discord.com/channels/${guildId}`
-                  : "https://discord.com/channels/@me"
-              }
-              target="_blank"
-              rel="noopener noreferrer"
+              href={`/discord-access?whop_id=${whopData.id}`}
             >
               Join Server
             </a>


### PR DESCRIPTION
## Summary
- always direct `Join Server` button to the OAuth join flow so members who accidentally left can rejoin

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d77809f48832c896b4cfebdf5d8bf