### PR TITLE
Enable Discord bot settings

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -53,6 +53,7 @@ export default function WhopDashboard() {
 
   // Owner-edit states
   const [isEditing, setIsEditing] = useState(false);
+  const [showDiscordSetup, setShowDiscordSetup] = useState(false);
   const [editName, setEditName] = useState("");
   const [editDescription, setEditDescription] = useState("");
   const [editBannerUrl, setEditBannerUrl] = useState("");
@@ -478,6 +479,8 @@ export default function WhopDashboard() {
       setEditLandingTexts={setEditLandingTexts}
       editModules={editModules}
       setEditModules={setEditModules}
+      showDiscordSetup={showDiscordSetup}
+      setShowDiscordSetup={setShowDiscordSetup}
     />
   );
 }

--- a/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
+++ b/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
@@ -8,6 +8,7 @@ import {
   FaUsers,
   FaPlus,
   FaTachometerAlt,
+  FaDiscord,
 } from "react-icons/fa";
 import "../../../styles/whop-dashboard/_owner.scss";
 
@@ -19,6 +20,8 @@ export default function OwnerActionButtons({
   setViewAsMemberMode,
   setIsCampaignModalOpen,
   whopData, // needed for Whop ID
+  showDiscordSetup,
+  setShowDiscordSetup,
 }) {
   const openDashboard = () => {
     // redirect to /dashboard with whop_id parameter
@@ -40,6 +43,14 @@ export default function OwnerActionButtons({
           >
             Cancel
           </button>
+          {whopData.modules?.discord_access && (
+            <button
+              className="whop-discord-btn"
+              onClick={() => setShowDiscordSetup(!showDiscordSetup)}
+            >
+              <FaDiscord /> Discord Setup
+            </button>
+          )}
         </>
       ) : (
         <>
@@ -65,6 +76,14 @@ export default function OwnerActionButtons({
           <button className="whop-dashboard-btn" onClick={openDashboard}>
             <FaTachometerAlt /> Dashboard
           </button>
+          {whopData.modules?.discord_access && (
+            <button
+              className="whop-discord-btn"
+              onClick={() => setShowDiscordSetup(!showDiscordSetup)}
+            >
+              <FaDiscord /> Discord Setup
+            </button>
+          )}
         </>
       )}
     </div>

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -76,6 +76,8 @@ export default function OwnerMode({
   setEditLandingTexts,
   editModules,
   setEditModules,
+  showDiscordSetup,
+  setShowDiscordSetup,
 }) {
   if (!whopData) return null;
 
@@ -148,6 +150,8 @@ export default function OwnerMode({
           handleDelete={handleDelete}
           setViewAsMemberMode={setViewAsMemberMode}
           setIsCampaignModalOpen={setIsCampaignModalOpen}
+          showDiscordSetup={showDiscordSetup}
+          setShowDiscordSetup={setShowDiscordSetup}
         />
 
         {/* Modules section */}
@@ -170,7 +174,7 @@ export default function OwnerMode({
           />
         )}
 
-        {editModules.discord_access && (
+        {editModules.discord_access && showDiscordSetup && (
           <DiscordSetupSection isEditing={isEditing} whopId={whopData.id} />
         )}
 


### PR DESCRIPTION
## Summary
- add a button to toggle Discord bot settings
- hide or show Discord setup section based on toggle

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f9ccde8832c8275e511c60c7a1a