### PR TITLE
Implement Discord setup modal

### DIFF
--- a/src/pages/WhopDashboard/components/DiscordSetupModal.jsx
+++ b/src/pages/WhopDashboard/components/DiscordSetupModal.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Modal from "../../../components/Modal";
+import DiscordSetupSection from "./DiscordSetupSection";
+
+export default function DiscordSetupModal({ isOpen, onClose, whopId }) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <DiscordSetupSection isEditing={true} whopId={whopId} />
+    </Modal>
+  );
+}

--- a/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
+++ b/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
@@ -46,7 +46,7 @@ export default function OwnerActionButtons({
           {whopData.modules?.discord_access && (
             <button
               className="whop-discord-btn"
-              onClick={() => setShowDiscordSetup(!showDiscordSetup)}
+              onClick={() => setShowDiscordSetup(true)}
             >
               <FaDiscord /> Discord Setup
             </button>
@@ -79,7 +79,7 @@ export default function OwnerActionButtons({
           {whopData.modules?.discord_access && (
             <button
               className="whop-discord-btn"
-              onClick={() => setShowDiscordSetup(!showDiscordSetup)}
+              onClick={() => setShowDiscordSetup(true)}
             >
               <FaDiscord /> Discord Setup
             </button>

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -10,6 +10,7 @@ import OwnerActionButtons from "./OwnerActionButtons";
 import FeaturesSection from "./FeaturesSection";
 import CourseSection from "./CourseSection";
 import DiscordSetupSection from "./DiscordSetupSection";
+import DiscordSetupModal from "./DiscordSetupModal";
 import CampaignsSection from "./CampaignsSection";
 import MembersSection from "./MembersSection";
 import CampaignModal from "./CampaignModal";
@@ -174,8 +175,12 @@ export default function OwnerMode({
           />
         )}
 
-        {editModules.discord_access && showDiscordSetup && (
-          <DiscordSetupSection isEditing={isEditing} whopId={whopData.id} />
+        {editModules.discord_access && (
+          <DiscordSetupModal
+            isOpen={showDiscordSetup}
+            onClose={() => setShowDiscordSetup(false)}
+            whopId={whopData.id}
+          />
         )}
 
         {editModules.course && (


### PR DESCRIPTION
## Summary
- enable `Discord Setup` button to show configuration modal
- show `DiscordSetupModal` in `OwnerMode`
- implement new `DiscordSetupModal` component

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d81c9ddf8832c9c8fd841af07fafb