### PR TITLE
Improve Discord setup modal

### DIFF
--- a/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
+++ b/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { FaCheckCircle } from "react-icons/fa";
 
 export default function DiscordSetupSection({ isEditing, whopId }) {
   const [guildId, setGuildId] = useState("");
@@ -116,7 +117,9 @@ export default function DiscordSetupSection({ isEditing, whopId }) {
         <p>Loading...</p>
       ) : guildId ? (
         <div>
-          <p>Connected server ID: {guildId}</p>
+          <p className="discord-connected-message">
+            <FaCheckCircle /> Discord Connected: {guildId}
+          </p>
           {isEditing && discordVerified && roles.length > 0 && (
             <div className="discord-settings-form">
               <label>

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -839,3 +839,45 @@
     color: var(--error-color);
   }
 }
+
+.discord-setup-section {
+  margin-top: var(--spacing-lg);
+  text-align: center;
+
+  .discord-connected-message {
+    color: var(--success-color);
+    font-weight: 600;
+    margin-bottom: var(--spacing-md);
+
+    svg {
+      margin-right: var(--spacing-xs);
+    }
+  }
+
+  .discord-settings-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    align-items: center;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-xs);
+      font-size: 0.9rem;
+      color: var(--text-color);
+    }
+
+    select {
+      padding: var(--spacing-xs);
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-base);
+      background: var(--surface-color);
+      color: var(--text-color);
+    }
+
+    button {
+      margin-top: var(--spacing-sm);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- show a green "Discord Connected" notice with guild ID
- style Discord settings form inside owner dashboard

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ec55ed5d8832cb9370f23962ce0b3