### PR TITLE
Fix Discord join role assignment and add UI feedback

### DIFF
--- a/discord-bot/bot.js
+++ b/discord-bot/bot.js
@@ -101,10 +101,11 @@ setInterval(async () => {
     conn = await mysql.createConnection(DB_CONFIG);
     for (const guild of client.guilds.cache.values()) {
       const [[srvRow]] = await conn.execute(
-        'SELECT whop_id, expire_action, expire_role_id FROM discord_servers WHERE guild_id=? LIMIT 1',
+        'SELECT whop_id, join_role_id, expire_action, expire_role_id FROM discord_servers WHERE guild_id=? LIMIT 1',
         [guild.id]
       );
       const whopId = srvRow ? srvRow.whop_id : null;
+      const joinRoleId = srvRow ? srvRow.join_role_id : null;
       const expireAction = srvRow ? srvRow.expire_action : 'kick';
       const expireRoleId = srvRow ? srvRow.expire_role_id : null;
       if (!whopId) continue;
@@ -156,6 +157,8 @@ setInterval(async () => {
               member.id,
             ])
             .catch(() => null);
+        } else if (joinRoleId && !member.roles.cache.has(joinRoleId)) {
+          await member.roles.add(joinRoleId).catch(() => null);
         }
       }
     }

--- a/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
+++ b/src/pages/WhopDashboard/components/DiscordSetupSection.jsx
@@ -10,6 +10,7 @@ export default function DiscordSetupSection({ isEditing, whopId }) {
   const [joinRole, setJoinRole] = useState("");
   const [expireAction, setExpireAction] = useState("kick");
   const [expireRole, setExpireRole] = useState("");
+  const [saveStatus, setSaveStatus] = useState("idle");
   const DISCORD_CLIENT_ID = "1391881188901388348";
 
   useEffect(() => {
@@ -79,8 +80,9 @@ export default function DiscordSetupSection({ isEditing, whopId }) {
   };
 
   const handleSaveSettings = async () => {
+    setSaveStatus("saving");
     try {
-      await fetch("https://app.byxbot.com/php/discord_link.php", {
+      const res = await fetch("https://app.byxbot.com/php/discord_link.php", {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -92,7 +94,16 @@ export default function DiscordSetupSection({ isEditing, whopId }) {
           expire_role_id: expireRole || null,
         }),
       });
-    } catch {}
+      const json = await res.json();
+      if (json.status === "success") {
+        setSaveStatus("saved");
+        setTimeout(() => setSaveStatus("idle"), 3000);
+      } else {
+        setSaveStatus("error");
+      }
+    } catch {
+      setSaveStatus("error");
+    }
   };
 
   const inviteUrl =
@@ -140,7 +151,9 @@ export default function DiscordSetupSection({ isEditing, whopId }) {
                   ))}
                 </select>
               )}
-              <button className="primary-btn" onClick={handleSaveSettings}>Save Settings</button>
+              <button className="primary-btn" onClick={handleSaveSettings} disabled={saveStatus==='saving'}>
+                {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
+              </button>
               <button className="primary-btn" onClick={handleDisconnect}>Disconnect</button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- assign join roles in the Discord bot during periodic checks
- show save feedback in the dashboard Discord setup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873b7789448832ca4bbc0c2f597af30