### PR TITLE
Move affiliate management to main dashboard

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -11,6 +11,9 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
+import AffiliateSection from "./WhopDashboard/components/AffiliateSection";
+import fetchAffiliateLinks from "./WhopDashboard/fetchAffiliateLinks";
+import handleUpdateAffiliateLink from "./WhopDashboard/handleUpdateAffiliateLink";
 import "../styles/dashboard.scss";
 
 export default function Dashboard() {
@@ -28,6 +31,11 @@ export default function Dashboard() {
   const [moderators, setModerators] = useState([]);
   const [inviteEmail, setInviteEmail] = useState("");
   const [loadingAction, setLoadingAction] = useState(false);
+
+  // Affiliate links
+  const [affiliateLinks, setAffiliateLinks] = useState([]);
+  const [affiliateLoading, setAffiliateLoading] = useState(false);
+  const [affiliateError, setAffiliateError] = useState("");
 
   const [chartData, setChartData] = useState([]);
   const [filterText, setFilterText] = useState("");
@@ -391,6 +399,38 @@ export default function Dashboard() {
     } finally {
       setLoadingAction(false);
     }
+  };
+
+  // 13) Affiliate links
+  const fetchAffiliates = (wid) =>
+    fetchAffiliateLinks(wid, setAffiliateLoading, setAffiliateError, setAffiliateLinks);
+
+  useEffect(() => {
+    if (whopId && role === "owner") {
+      fetchAffiliates(whopId);
+    }
+  }, [whopId, role]);
+
+  const handleAffiliateChange = async (id, payout) => {
+    await handleUpdateAffiliateLink(
+      id,
+      payout,
+      false,
+      showNotification,
+      fetchAffiliates,
+      whopId
+    );
+  };
+
+  const handleAffiliateDelete = async (id) => {
+    await handleUpdateAffiliateLink(
+      id,
+      0,
+      true,
+      showNotification,
+      fetchAffiliates,
+      whopId
+    );
   };
 
   // payment filtering and pagination
@@ -757,6 +797,16 @@ export default function Dashboard() {
           </table>
         )}
       </div>
+
+      {role === "owner" && (
+        <AffiliateSection
+          links={affiliateLinks}
+          loading={affiliateLoading}
+          error={affiliateError}
+          onChangePercent={handleAffiliateChange}
+          onDelete={handleAffiliateDelete}
+        />
+      )}
 
       <div className="table-section">
         <h2>Team (Moderators)</h2>

--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -22,8 +22,6 @@ import handleExpireCampaign from "./handleExpireCampaign";
 import fetchMembers from "./fetchMembers";
 import handleCancelMember from "./handleCancelMember";
 import handleRequestWaitlist from "./handleRequestWaitlist";
-import fetchAffiliateLinks from "./fetchAffiliateLinks";
-import handleUpdateAffiliateLink from "./handleUpdateAffiliateLink";
 
 import LoadingOverlay from "./components/LoadingOverlay";
 import ErrorView from "./components/ErrorView";
@@ -304,30 +302,12 @@ export default function WhopDashboard() {
     }
   }, [whopData]);
 
-  // 1️⃣4️⃣ Fetch affiliate links (owner)
-  const [affiliateLinks, setAffiliateLinks] = useState([]);
-  const [affiliateLoading, setAffiliateLoading] = useState(false);
-  const [affiliateError, setAffiliateError] = useState("");
-  const fetchAffiliates = (wid) =>
-    fetchAffiliateLinks(wid, setAffiliateLoading, setAffiliateError, setAffiliateLinks);
-  useEffect(() => {
-    if (whopData?.is_owner && whopData.modules?.affiliate) {
-      fetchAffiliates(whopData.id);
-    }
-  }, [whopData]);
 
   // 1️⃣4️⃣ Cancel one paid member
   const onCancelMember = async (uid) => {
     await handleCancelMember(uid, whopData, showConfirm, showNotification, fetchMembers);
   };
 
-  // 1️⃣5️⃣ Update or delete affiliate link
-  const onAffiliateChange = async (id, payout) => {
-    await handleUpdateAffiliateLink(id, payout, false, showNotification, fetchAffiliates, whopData.id);
-  };
-  const onAffiliateDelete = async (id) => {
-    await handleUpdateAffiliateLink(id, 0, true, showNotification, fetchAffiliates, whopData.id);
-  };
 
   // ⭐ Request waitlist
   const onRequestWaitlist = async (wid, answers) => {
@@ -478,11 +458,6 @@ export default function WhopDashboard() {
       membersLoading={membersLoading}
       membersError={membersError}
       handleCancelMember={onCancelMember}
-      affiliateLinks={affiliateLinks}
-      affiliateLoading={affiliateLoading}
-      affiliateError={affiliateError}
-      handleAffiliateChange={onAffiliateChange}
-      handleAffiliateDelete={onAffiliateDelete}
       handleBack={onBack}
       isCampaignModalOpen={isCampaignModalOpen}
       fetchCampaigns={fetchCampaignsBound}

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -13,7 +13,6 @@ import DiscordSetupSection from "./DiscordSetupSection";
 import DiscordSetupModal from "./DiscordSetupModal";
 import CampaignsSection from "./CampaignsSection";
 import MembersSection from "./MembersSection";
-import AffiliateSection from "./AffiliateSection";
 import CampaignModal from "./CampaignModal";
 import OwnerTextMenu from "./OwnerTextMenu";
 import OwnerModules from "./OwnerModules";
@@ -59,11 +58,6 @@ export default function OwnerMode({
   membersLoading,
   membersError,
   handleCancelMember,
-  affiliateLinks,
-  affiliateLoading,
-  affiliateError,
-  handleAffiliateChange,
-  handleAffiliateDelete,
   handleBack,
   isCampaignModalOpen,
   fetchCampaigns,
@@ -218,15 +212,6 @@ export default function OwnerMode({
             membersError={membersError}
             membershipsList={membershipsList}
             handleCancelMember={handleCancelMember}
-          />
-        )}
-        {whopData.is_owner && editModules.affiliate && (
-          <AffiliateSection
-            links={affiliateLinks}
-            loading={affiliateLoading}
-            error={affiliateError}
-            onChangePercent={handleAffiliateChange}
-            onDelete={handleAffiliateDelete}
           />
         )}
       </div>

--- a/src/pages/WhopDashboard/handleUpdateAffiliateLink.js
+++ b/src/pages/WhopDashboard/handleUpdateAffiliateLink.js
@@ -22,9 +22,9 @@ export default async function handleUpdateAffiliateLink(
     if (!res.ok || json.status !== "success") {
       throw new Error(json.message || `HTTP ${res.status}`);
     }
-    showNotification("Saved");
+    showNotification({ type: "success", message: "Saved" });
     await fetchLinks(whopId);
   } catch (err) {
-    showNotification("Error: " + err.message, "error");
+    showNotification({ type: "error", message: "Error: " + err.message });
   }
 }

--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -231,3 +231,77 @@ button.btn-unban:hover {
 .btn-invite {
     margin-left: 10px;
 }
+
+.whop-affiliate-section {
+  width: 100%;
+  margin-top: var(--spacing-lg);
+
+  .affiliate-section-title {
+    font-size: 1.5rem;
+    color: var(--text-color);
+    text-align: center;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .members-loading,
+  .members-error,
+  .members-empty {
+    text-align: center;
+    font-size: 1rem;
+    color: var(--muted-color);
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .members-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    color: var(--text-color);
+
+    thead {
+      background: var(--border-color);
+      th {
+        padding: var(--spacing-xs) var(--spacing-sm);
+        text-align: left;
+        font-weight: 600;
+        color: var(--text-color);
+      }
+    }
+
+    tbody {
+      tr {
+        background: var(--surface-color);
+        &:nth-child(even) {
+          background: var(--border-color-hover);
+        }
+        &:hover {
+          background: var(--border-color);
+        }
+        td {
+          padding: var(--spacing-xs) var(--spacing-sm);
+          border-bottom: 1px solid var(--border-color);
+          vertical-align: middle;
+
+          .member-cancel-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--spacing-xs);
+            background: var(--error-color);
+            color: #fff;
+            border: none;
+            border-radius: var(--radius-lg);
+            padding: 0.25rem 0.5rem;
+            font-size: 0.75rem;
+            cursor: pointer;
+            transition: background var(--transition), transform var(--transition);
+
+            &:hover {
+              background: var(--error-hover);
+              transform: translateY(-1px);
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove affiliate management section from legacy owner dashboard
- clean up unused affiliate state and imports
- fix `handleUpdateAffiliateLink` to display success/error messages correctly

## Testing
- `npm test --silent --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751e3c638c832c98508d15219da0bf