### PR TITLE
Fix affiliate redirect to increment clicks and route to whop

### DIFF
--- a/php/affiliate_redirect.php
+++ b/php/affiliate_redirect.php
@@ -6,10 +6,11 @@ require_once __DIR__ . '/config_login.php';
 $code = isset($_GET['code']) ? $_GET['code'] : '';
 if ($code === '') {
     http_response_code(400);
-    echo "Invalid affiliate link";
+    echo 'Invalid affiliate link';
     exit;
 }
 
+$slug = '';
 try {
     $pdo = new PDO(
         "mysql:host=$servername;dbname=$database;charset=utf8mb4",
@@ -17,10 +18,19 @@ try {
         $db_password,
         [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
     );
-    $upd = $pdo->prepare("UPDATE affiliate_links SET clicks = clicks + 1 WHERE code=:code");
+
+    // increment click counter
+    $upd = $pdo->prepare('UPDATE affiliate_links SET clicks = clicks + 1 WHERE code = :code');
     $upd->execute(['code' => $code]);
+
+    // fetch slug of related whop for redirect
+    $sel = $pdo->prepare(
+        'SELECT w.slug FROM affiliate_links al JOIN whops w ON al.whop_id = w.id WHERE al.code = :code LIMIT 1'
+    );
+    $sel->execute(['code' => $code]);
+    $slug = $sel->fetchColumn();
 } catch (Exception $e) {
-    // ignore
+    // ignore any database errors
 }
 
 setcookie('affiliate_code', $code, [
@@ -31,5 +41,9 @@ setcookie('affiliate_code', $code, [
     'samesite' => 'Lax',
 ]);
 
-header('Location: /');
+if ($slug) {
+    header('Location: /c/' . rawurlencode($slug));
+} else {
+    header('Location: /');
+}
 exit;


### PR DESCRIPTION
## Summary
- ensure affiliate redirect increments click counter and retrieves whop slug
- redirect users to `/c/<slug>` based on affiliate link

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6875244732c4832c9d324cd7c9031c8f