### PR TITLE
Fix affiliate redirect path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
         var params = new URLSearchParams(window.location.search);
         var af = params.get('af');
         if (af) {
-          window.location.href = '/php/affiliate_redirect.php?code=' + encodeURIComponent(af);
+          window.location.href = 'https://app.byxbot.com/php/affiliate_redirect.php?code=' + encodeURIComponent(af);
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- update link redirection to use full backend URL for affiliate redirects

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875274e7c10832c96317e36d40a7c9d