### PR TITLE
Allow home and whop pages without login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import React, { Suspense, lazy } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Sidebar from "./components/Sidebar";
 import BottomBar from "./components/BottomBar";
+import LoginPromptBar from "./components/LoginPromptBar";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Loading from "./components/Loading";
 
@@ -27,6 +28,7 @@ const DiscordAccess        = lazy(() => import("./pages/DiscordAccess"));
 const DiscordAccessSetup   = lazy(() => import("./pages/DiscordAccessSetup"));
 
 const App = () => {
+  const loggedIn = Boolean(localStorage.getItem('authToken'));
   return (
     <BrowserRouter>
       <Suspense fallback={<Loading />}>
@@ -121,15 +123,13 @@ const App = () => {
           <Route
             path="/c/:slug"
             element={
-              <ProtectedRoute>
-                <div className="app-container">
-                  <Sidebar />
-                  <main className="main-content">
-                    <WhopDashboard />
-                  </main>
-                  <BottomBar />
-                </div>
-              </ProtectedRoute>
+              <div className="app-container">
+                {loggedIn && <Sidebar />}
+                <main className={`main-content${loggedIn ? '' : ' no-sidebar'}`}> 
+                  <WhopDashboard />
+                </main>
+                {loggedIn ? <BottomBar /> : <LoginPromptBar />}
+              </div>
             }
           />
 
@@ -169,15 +169,13 @@ const App = () => {
           <Route
             path="/"
             element={
-              <ProtectedRoute>
-                <div className="app-container">
-                  <Sidebar />
-                  <main className="main-content">
-                    <Home />
-                  </main>
-                  <BottomBar />
-                </div>
-              </ProtectedRoute>
+              <div className="app-container">
+                {loggedIn && <Sidebar />}
+                <main className={`main-content${loggedIn ? '' : ' no-sidebar'}`}> 
+                  <Home />
+                </main>
+                {loggedIn ? <BottomBar /> : <LoginPromptBar />}
+              </div>
             }
           />
 

--- a/src/components/LoginPromptBar.jsx
+++ b/src/components/LoginPromptBar.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import '../styles/login-prompt-bar.scss';
+
+export default function LoginPromptBar() {
+  const navigate = useNavigate();
+  return (
+    <div className="login-prompt-bar">
+      <button className="btn" onClick={() => navigate('/login')}>Get Inside</button>
+    </div>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import './index.scss';
 import './styles/App.scss';
 import './styles/sidebar.scss';
 import './styles/bottombar.scss';
+import './styles/login-prompt-bar.scss';
 import './styles/login.scss';
 import './styles/register.scss';
 import './styles/profile.scss';

--- a/src/styles/login-prompt-bar.scss
+++ b/src/styles/login-prompt-bar.scss
@@ -1,0 +1,17 @@
+.login-prompt-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: var(--primary-color);
+  display: flex;
+  justify-content: center;
+  padding: var(--spacing-sm);
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.login-prompt-bar .btn {
+  background: #fff;
+  color: var(--primary-color);
+}

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -107,3 +107,7 @@
 .main-content {
   margin-left: var(--sidebar-width, 60px);
 }
+
+.main-content.no-sidebar {
+  margin-left: 0;
+}


### PR DESCRIPTION
## Summary
- add a LoginPromptBar component with styles
- load the new styles in index.js
- show optional Sidebar/BottomBar depending on auth state in App
- expose home and `/c/:slug` pages without requiring login
- tweak styles so content shifts when sidebar hidden

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687564a99afc832c995a9d6e229eb8c9