### PR TITLE
Allow viewing /c pages without login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,10 +42,11 @@ const App = () => {
             path="/intro"
             element={
               <div className="app-container">
-                <Sidebar />
-                <main className="main-content">
+                {loggedIn && <Sidebar />}
+                <main className={`main-content${loggedIn ? '' : ' no-sidebar'}`}>
                   <Intro />
                 </main>
+                {loggedIn ? <BottomBar /> : <LoginPromptBar />}
               </div>
             }
           />


### PR DESCRIPTION
## Summary
- allow `get_whop.php` to return data even if not logged in
- require login only for `owner=me` requests
- return user-specific fields conditionally
- hide sidebar and bottom bar on `/intro` when logged out

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6876658b3ed8832cb31b1d69baf69188