### PR TITLE
Fix duplicate useAuth import

### DIFF
--- a/src/components/BottomBar.jsx
+++ b/src/components/BottomBar.jsx
@@ -6,7 +6,6 @@ import '../styles/bottombar.scss';
 import { FiMenu, FiSun, FiMoon } from 'react-icons/fi';
 import { FaSignOutAlt } from 'react-icons/fa';
 import { useTheme } from '../context/ThemeContext';
-import { useAuth } from '../context/AuthContext';
 
 export default function BottomBar() {
   const { theme, setLight, setDark } = useTheme();


### PR DESCRIPTION
## Summary
- remove redundant `useAuth` import from `BottomBar`

## Testing
- `npm test --silent -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687680ef8fd4832cb3550948dba811cf