### PR TITLE
Improve login flow and review visibility

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -321,7 +321,7 @@ export default function WhopDashboard() {
   const onRequestWaitlist = async (wid, answers) => {
     setMemberLoading(true);
     try {
-      await handleRequestWaitlist(wid, answers, showNotification);
+      await handleRequestWaitlist(wid, answers, showNotification, navigate);
       // on success, refresh whopData
       fetchWhopData(
         whopData.slug,

--- a/src/pages/WhopDashboard/components/LandingPage.jsx
+++ b/src/pages/WhopDashboard/components/LandingPage.jsx
@@ -201,6 +201,7 @@ export default function LandingPage({
             </div>
           ))}
         </div>
+        {whopData.can_review ? (
         <div className="review-form">
           <div className="rating-select">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -242,6 +243,7 @@ export default function LandingPage({
             Submit Review
           </button>
         </div>
+        ) : null}
       </section>
 
       {/* FEATURES SECTION - dynamic */}

--- a/src/pages/WhopDashboard/handleJoinFree.js
+++ b/src/pages/WhopDashboard/handleJoinFree.js
@@ -45,7 +45,10 @@ export default async function handleJoinFree(
     });
     const json = await res.json();
 
-    if (!res.ok) {
+    if (res.status === 401) {
+      showNotification({ type: "error", message: "Please log in to continue." });
+      navigate("/login");
+    } else if (!res.ok) {
       // If joining failed, show error notification
       showNotification({
         type: "error",

--- a/src/pages/WhopDashboard/handleRequestWaitlist.js
+++ b/src/pages/WhopDashboard/handleRequestWaitlist.js
@@ -8,7 +8,7 @@
  * @returns {Promise<object>}   Parsed JSON response from the server.
  * @throws {Error}              If the server responds with an error or non‐JSON.
  */
-export default async function handleRequestWaitlist(whopId, answers) {
+export default async function handleRequestWaitlist(whopId, answers, showNotification, navigate) {
   // Build the request payload – send "answers" array directly
   const payload = {
     whop_id: whopId,
@@ -33,6 +33,14 @@ export default async function handleRequestWaitlist(whopId, answers) {
     json = JSON.parse(text);
   } catch {
     throw new Error("Server did not return valid JSON.");
+  }
+
+  if (res.status === 401) {
+    if (showNotification) {
+      showNotification({ type: "error", message: "Please log in to continue." });
+    }
+    if (navigate) navigate("/login");
+    throw new Error("Unauthorized");
   }
 
   // Handle conflict (already requested) or explicit error

--- a/src/pages/WhopDashboard/handleSubscribe.js
+++ b/src/pages/WhopDashboard/handleSubscribe.js
@@ -90,8 +90,11 @@ export default async function handleSubscribe(
       );
     }
 
-    if (!res.ok || data.status !== "success") {
-      // API returned an error (e.g. 400 or 401, or {status:"error"})
+    if (res.status === 401) {
+      showNotification({ type: "error", message: "Please log in to continue." });
+      navigate("/login");
+    } else if (!res.ok || data.status !== "success") {
+      // API returned an error (e.g. 400, 403, etc)
       const msg = data.message || `HTTP error ${res.status}`;
       showNotification({ type: "error", message: msg });
     } else {


### PR DESCRIPTION
## Summary
- add `can_review` field to whop data
- show review form only when `can_review` is true
- redirect to login for unauthorized subscribe/join/waitlist actions

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68768a1942f8832c983b1ece28423533