### PR TITLE
Fix undefined affiliate setters

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -277,6 +277,8 @@ export default function WhopDashboard() {
       setEditLandingTexts,
       setEditModules,
       setEditCourseSteps,
+      setEditAffiliatePercent,
+      setEditAffiliateRecurring,
       waitlistEnabled,
       waitlistQuestions,
       editLongDescription,

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -24,6 +24,8 @@ export default async function handleSaveWhop(
   setEditLandingTexts,
   setEditModules,
   setEditCourseSteps,
+  setEditAffiliatePercent,
+  setEditAffiliateRecurring,
   waitlistEnabled,         // new parameter
   waitlistQuestions,       // new parameter
   editLongDescription,


### PR DESCRIPTION
## Summary
- include affiliate setter parameters in `handleSaveWhop`
- pass affiliate setters when calling `handleSaveWhop`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876b4518c50832c91295669ee2ce40f