### PR TITLE
Remove affiliate settings from WhopDashboard edit page

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -499,10 +499,6 @@ export default function WhopDashboard() {
       setEditLandingTexts={setEditLandingTexts}
       editModules={editModules}
       setEditModules={setEditModules}
-      editAffiliatePercent={editAffiliatePercent}
-      setEditAffiliatePercent={setEditAffiliatePercent}
-      editAffiliateRecurring={editAffiliateRecurring}
-      setEditAffiliateRecurring={setEditAffiliateRecurring}
       showDiscordSetup={showDiscordSetup}
       setShowDiscordSetup={setShowDiscordSetup}
     />

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -16,7 +16,6 @@ import MembersSection from "./MembersSection";
 import CampaignModal from "./CampaignModal";
 import OwnerTextMenu from "./OwnerTextMenu";
 import OwnerModules from "./OwnerModules";
-import AffiliateDefaultsSection from "./AffiliateDefaultsSection";
 
 export default function OwnerMode({
   whopData,
@@ -78,10 +77,6 @@ export default function OwnerMode({
   setEditLandingTexts,
   editModules,
   setEditModules,
-  editAffiliatePercent,
-  setEditAffiliatePercent,
-  editAffiliateRecurring,
-  setEditAffiliateRecurring,
   showDiscordSetup,
   setShowDiscordSetup,
 }) {
@@ -166,17 +161,6 @@ export default function OwnerMode({
           setEditModules={setEditModules}
           isEditing={isEditing}
         />
-
-        {editModules.affiliate && (
-          <AffiliateDefaultsSection
-            isEditing={isEditing}
-            defaultPercent={editAffiliatePercent}
-            setDefaultPercent={setEditAffiliatePercent}
-            recurring={editAffiliateRecurring}
-            setRecurring={setEditAffiliateRecurring}
-          />
-        )}
-
         {/* Features section */}
         {editModules.text && (
           <FeaturesSection


### PR DESCRIPTION
## Summary
- remove `AffiliateDefaultsSection` from Whop dashboard edit view
- update `OwnerMode` props accordingly

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6876c14112c8832c8dfe6b72a4cdff75