### PR TITLE
Fix affiliate recurring payouts and dashboard editing

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -440,10 +440,6 @@ export default function Dashboard() {
     );
   };
 
-  const handleAffiliateRecurring = async (id, recurring) => {
-    await handleAffiliateChange(id, undefined, recurring);
-  };
-
   const handleAffiliateDelete = async (id) => {
     await handleUpdateAffiliateLink(
       id,
@@ -857,8 +853,7 @@ export default function Dashboard() {
             links={affiliateLinks}
             loading={affiliateLoading}
             error={affiliateError}
-            onChangePercent={(id, val) => handleAffiliateChange(id, val, undefined)}
-            onChangeRecurring={handleAffiliateRecurring}
+            onSave={handleAffiliateChange}
             onDelete={handleAffiliateDelete}
           />
         </>

--- a/src/pages/WhopDashboard/components/AffiliateSection.jsx
+++ b/src/pages/WhopDashboard/components/AffiliateSection.jsx
@@ -1,15 +1,44 @@
 // src/pages/WhopDashboard/components/AffiliateSection.jsx
-import React from "react";
+import React, { useState } from "react";
 import "../../../styles/whop-dashboard/_owner.scss";
 
 export default function AffiliateSection({
   links,
   loading,
   error,
-  onChangePercent,
+  onSave,
   onDelete,
-  onChangeRecurring,
 }) {
+  const [edits, setEdits] = useState({});
+
+  const onChangePercent = (id, val) => {
+    setEdits((prev) => ({
+      ...prev,
+      [id]: { ...(prev[id] || {}), payout_percent: val },
+    }));
+  };
+
+  const onChangeRecurring = (id, recurring) => {
+    setEdits((prev) => ({
+      ...prev,
+      [id]: { ...(prev[id] || {}), payout_recurring: recurring },
+    }));
+  };
+
+  const handleSave = (id) => {
+    const current = links.find((l) => l.id === id) || {};
+    const edit = edits[id] || {};
+    onSave(
+      id,
+      edit.payout_percent !== undefined ? edit.payout_percent : current.payout_percent,
+      edit.payout_recurring !== undefined ? edit.payout_recurring : current.payout_recurring
+    );
+    setEdits((prev) => {
+      const copy = { ...prev };
+      delete copy[id];
+      return copy;
+    });
+  };
   return (
     <div className="whop-affiliate-section">
       <h2 className="affiliate-section-title">Affiliates</h2>
@@ -42,7 +71,11 @@ export default function AffiliateSection({
                 <td>
                   <input
                     type="number"
-                    value={l.payout_percent}
+                    value={
+                      edits[l.id]?.payout_percent !== undefined
+                        ? edits[l.id].payout_percent
+                        : l.payout_percent
+                    }
                     min="0"
                     max="100"
                     step="0.1"
@@ -53,14 +86,31 @@ export default function AffiliateSection({
                 </td>
                 <td>
                   <select
-                    value={l.payout_recurring ? "1" : "0"}
-                    onChange={(e) => onChangeRecurring(l.id, e.target.value === "1")}
+                    value={
+                      edits[l.id]?.payout_recurring !== undefined
+                        ? edits[l.id].payout_recurring
+                          ? "1"
+                          : "0"
+                        : l.payout_recurring
+                        ? "1"
+                        : "0"
+                    }
+                    onChange={(e) =>
+                      onChangeRecurring(l.id, e.target.value === "1")
+                    }
                   >
                     <option value="0">One-time</option>
                     <option value="1">Recurring</option>
                   </select>
                 </td>
                 <td>
+                  <button
+                    className="member-save-btn"
+                    onClick={() => handleSave(l.id)}
+                    disabled={!edits[l.id]}
+                  >
+                    Save
+                  </button>
                   <button
                     className="member-cancel-btn"
                     onClick={() => onDelete(l.id)}


### PR DESCRIPTION
## Summary
- allow editing affiliate payout percents and recurring status with a save button
- support affiliate recurring payouts when processing memberships

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877fc17df70832ca0dbc414242dc996