### PR TITLE
Fix affiliate settings saving and validation

### DIFF
--- a/php/get_affiliate_links.php
+++ b/php/get_affiliate_links.php
@@ -68,7 +68,20 @@ try {
     );
     $stmt->execute(['wid' => $whop_id]);
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    echo json_encode(["status" => "success", "data" => $rows]);
+    $formatted = array_map(function ($row) {
+        return [
+            'id' => (int)$row['id'],
+            'user_id' => (int)$row['user_id'],
+            'username' => $row['username'],
+            'code' => $row['code'],
+            'payout_percent' => floatval($row['payout_percent']),
+            'payout_recurring' => intval($row['payout_recurring']),
+            'clicks' => (int)$row['clicks'],
+            'signups' => (int)$row['signups'],
+            'earned' => floatval($row['earned']),
+        ];
+    }, $rows);
+    echo json_encode(["status" => "success", "data" => $formatted]);
 } catch (Exception $e) {
     http_response_code(500);
     echo json_encode(["status" => "error", "message" => $e->getMessage()]);

--- a/php/update_affiliate_defaults.php
+++ b/php/update_affiliate_defaults.php
@@ -19,6 +19,10 @@ if (!$user_id) {
 $data = json_decode(file_get_contents('php://input'), true);
 $whop_id = isset($data['whop_id']) ? (int)$data['whop_id'] : 0;
 $percent = isset($data['affiliate_default_percent']) ? floatval($data['affiliate_default_percent']) : null;
+if ($percent !== null) {
+    if ($percent < 0) $percent = 0.0;
+    if ($percent > 100) $percent = 100.0;
+}
 $recurring = isset($data['affiliate_recurring']) ? intval($data['affiliate_recurring']) : 0;
 if ($whop_id <= 0 || $percent === null) {
     http_response_code(400);

--- a/php/update_affiliate_link.php
+++ b/php/update_affiliate_link.php
@@ -22,6 +22,10 @@ if (!$user_id) {
 $data = json_decode(file_get_contents('php://input'), true);
 $link_id = isset($data['link_id']) ? (int)$data['link_id'] : 0;
 $payout = isset($data['payout_percent']) ? floatval($data['payout_percent']) : null;
+if ($payout !== null) {
+    if ($payout < 0) $payout = 0.0;
+    if ($payout > 100) $payout = 100.0;
+}
 $recurring = isset($data['payout_recurring']) ? intval($data['payout_recurring']) : null;
 $delete = isset($data['delete']) ? boolval($data['delete']) : false;
 if ($link_id <= 0) {

--- a/php/update_whop.php
+++ b/php/update_whop.php
@@ -199,7 +199,9 @@ try {
         ':landing_texts'    => $landing_json,
         ':modules'                 => $modules_json,
         ':course_steps'            => $course_json,
-        ':affiliate_default_percent' => isset($data['affiliate_default_percent']) ? floatval($data['affiliate_default_percent']) : 0,
+        ':affiliate_default_percent' => isset($data['affiliate_default_percent'])
+            ? max(0.0, min(100.0, floatval($data['affiliate_default_percent'])))
+            : 0,
         ':affiliate_recurring'       => isset($data['affiliate_recurring']) ? intval($data['affiliate_recurring']) : 0,
         ':id'                        => $whopId
     ]);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -427,6 +427,7 @@ export default function Dashboard() {
     } else {
       newPayout = link.payout_percent;
     }
+    newPayout = Math.min(100, Math.max(0, newPayout));
     const newRecurring =
       typeof recurring === "boolean" ? recurring : Boolean(link.payout_recurring);
     await handleUpdateAffiliateLink(
@@ -460,7 +461,7 @@ export default function Dashboard() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           whop_id: whopId,
-          affiliate_default_percent: affiliateDefaultPercent,
+          affiliate_default_percent: Math.min(100, Math.max(0, affiliateDefaultPercent)),
           affiliate_recurring: affiliateRecurring ? 1 : 0,
         }),
       });

--- a/src/pages/WhopDashboard/components/AffiliateDefaultsSection.jsx
+++ b/src/pages/WhopDashboard/components/AffiliateDefaultsSection.jsx
@@ -21,7 +21,14 @@ export default function AffiliateDefaultsSection({
             max="100"
             step="0.1"
             value={defaultPercent}
-            onChange={(e) => setDefaultPercent(e.target.value)}
+            onChange={(e) => {
+              const val = parseFloat(e.target.value);
+              if (!isNaN(val)) {
+                setDefaultPercent(Math.min(100, Math.max(0, val)));
+              } else {
+                setDefaultPercent(0);
+              }
+            }}
           />
         </label>
         <label>

--- a/src/pages/WhopDashboard/components/AffiliateSection.jsx
+++ b/src/pages/WhopDashboard/components/AffiliateSection.jsx
@@ -79,9 +79,13 @@ export default function AffiliateSection({
                     min="0"
                     max="100"
                     step="0.1"
-                    onChange={(e) =>
-                      onChangePercent(l.id, parseFloat(e.target.value))
-                    }
+                    onChange={(e) => {
+                      const val = parseFloat(e.target.value);
+                      if (!isNaN(val)) {
+                        const clamped = Math.min(100, Math.max(0, val));
+                        onChangePercent(l.id, clamped);
+                      }
+                    }}
                   />
                 </td>
                 <td>

--- a/src/pages/WhopDashboard/fetchAffiliateLinks.js
+++ b/src/pages/WhopDashboard/fetchAffiliateLinks.js
@@ -15,7 +15,12 @@ export default async function fetchAffiliateLinks(
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const json = await res.json();
     if (json.status !== "success") throw new Error(json.message || "Error");
-    setLinks(json.data);
+    const parsed = json.data.map((row) => ({
+      ...row,
+      payout_percent: parseFloat(row.payout_percent),
+      payout_recurring: Number(row.payout_recurring) === 1 ? 1 : 0,
+    }));
+    setLinks(parsed);
   } catch (err) {
     setError("Unable to load affiliates: " + err.message);
   } finally {


### PR DESCRIPTION
## Summary
- clamp affiliate payout percentage between 0 and 100 everywhere
- parse numeric fields for affiliate links to ensure editing recurring mode works
- fix recurring toggle not saving due to string numbers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878036c6530832ca1b1ae96c1be3c4b