### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,15 @@
 // src/App.jsx
 
-import React, { Suspense, lazy } from "react";
+import React, { Suspense, lazy, useState } from "react";
 import { useAuth } from "./context/AuthContext";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import Sidebar from "./components/Sidebar";
 import BottomBar from "./components/BottomBar";
 import LoginPromptBar from "./components/LoginPromptBar";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Loading from "./components/Loading";
+import MobileHeader from "./components/MobileHeader";
+import PageLoader from "./components/PageLoader";
 
 const Home                 = lazy(() => import("./pages/Home"));
 const Intro                = lazy(() => import("./pages/Intro"));
@@ -30,8 +32,10 @@ const DiscordAccessSetup   = lazy(() => import("./pages/DiscordAccessSetup"));
 
 const App = () => {
   const { isLoggedIn } = useAuth();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   return (
     <BrowserRouter>
+      <PageLoader />
       <Suspense fallback={<Loading />}>
         <Routes>
           {/* Public routes */}
@@ -43,8 +47,13 @@ const App = () => {
             path="/intro"
             element={
               <div className="app-container">
-                {isLoggedIn && <Sidebar />}
-                <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}>
+                {isLoggedIn && (
+                  <>
+                    <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                    <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  </>
+                )}
+                <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}> 
                   <Intro />
                 </main>
                 {isLoggedIn ? <BottomBar /> : <LoginPromptBar />}
@@ -58,7 +67,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Onboarding />
                   </main>
@@ -73,7 +83,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Setup />
                   </main>
@@ -86,7 +97,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <ChooseLink />
                   </main>
@@ -99,7 +111,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <FeaturesSetup />
                   </main>
@@ -112,7 +125,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <BannerSetup />
                   </main>
@@ -126,7 +140,12 @@ const App = () => {
             path="/c/:slug"
             element={
               <div className="app-container">
-                {isLoggedIn && <Sidebar />}
+                {isLoggedIn && (
+                  <>
+                    <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                    <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  </>
+                )}
                 <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}> 
                   <WhopDashboard />
                 </main>
@@ -141,7 +160,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Dashboard />
                   </main>
@@ -157,7 +177,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <SubmissionsOverview />
                   </main>
@@ -172,7 +193,12 @@ const App = () => {
             path="/"
             element={
               <div className="app-container">
-                {isLoggedIn && <Sidebar />}
+                {isLoggedIn && (
+                  <>
+                    <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                    <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  </>
+                )}
                 <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}> 
                   <Home />
                 </main>
@@ -187,7 +213,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Profile />
                   </main>
@@ -203,7 +230,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Balances />
                   </main>
@@ -219,7 +247,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Memberships />
                   </main>
@@ -235,7 +264,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <Payments />
                   </main>
@@ -251,7 +281,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <DiscordAccess />
                   </main>
@@ -267,7 +298,8 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <div className="app-container">
-                  <Sidebar />
+                  <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
                   <main className="main-content">
                     <DiscordAccessSetup />
                   </main>

--- a/src/components/MobileHeader.jsx
+++ b/src/components/MobileHeader.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { FiMenu } from 'react-icons/fi';
+import '../styles/mobile-header.scss';
+
+export default function MobileHeader({ onMenu }) {
+  return (
+    <header className="mobile-header">
+      <button
+        className="mobile-header__menu"
+        onClick={onMenu}
+        type="button"
+        aria-label="Open menu"
+      >
+        <FiMenu />
+      </button>
+    </header>
+  );
+}

--- a/src/components/PageLoader.jsx
+++ b/src/components/PageLoader.jsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import '../styles/page-loader.scss';
+
+export default function PageLoader() {
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    const timeout = setTimeout(() => setLoading(false), 400);
+    return () => clearTimeout(timeout);
+  }, [location]);
+
+  if (!loading) return null;
+  return (
+    <div className="page-loader">
+      <div className="spinner" />
+    </div>
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import "../styles/sidebar.scss";
+import { FiX } from "react-icons/fi";
 import Logo from "../assets/logo.png";
 import {
   FiHome,
@@ -16,7 +17,7 @@ import { FaUserShield, FaDollarSign } from "react-icons/fa";
 import ChatModal from "./Chat/ChatModal";
 import SearchModal from "./SearchModal";
 
-export default function Sidebar() {
+export default function Sidebar({ isOpen, onClose }) {
   const [avatarUrl, setAvatarUrl] = useState("");
   const [chatOpen, setChatOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -46,7 +47,21 @@ export default function Sidebar() {
 
   return (
     <>
-      <aside className="sidebar">
+      <aside className={`sidebar${isOpen ? ' open' : ''}`}
+        onClick={() => {
+          if (window.innerWidth <= 1024) onClose?.();
+        }}
+      >
+        <button
+          className="sidebar__close"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose?.();
+          }}
+          type="button"
+        >
+          <FiX />
+        </button>
         {/* Logo */}
         <div className="sidebar__logo">
           <img src={Logo} alt="Platform Logo" />

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,6 +3,8 @@
 @import './styles/design-system';
 @import './styles/sidebar';
 @import './styles/bottombar';
+@import './styles/mobile-header';
+@import './styles/page-loader';
 
 // Global reset
 * {

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -43,6 +43,7 @@ body.theme-light {
 
   --icon-size: 20px;
   --bottombar-height: 60px;
+  --sidebar-width: 60px;
 }
 
 /* --- Dark theme (optional) --- */
@@ -65,6 +66,7 @@ body.theme-dark {
   --border-color: rgba(255, 255, 255, 0.1);
   --shadow-soft: 0 4px 12px rgba(0, 0, 0, 0.15);
   --shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  --sidebar-width: 60px;
 }
 
 /* Reset & global styles */

--- a/src/styles/bottombar.scss
+++ b/src/styles/bottombar.scss
@@ -13,12 +13,16 @@
   background-color: rgba(233, 233, 233, 0.541);
   backdrop-filter: blur(5px);
   border-top: 1px solid var(--border-color);
-  display: flex;
+  display: none;
   align-items: center;
   padding: 0 var(--spacing-md);
   z-index: 9999;
   justify-content: space-between;
   box-shadow: var(--shadow-sm);
+
+  @include respond(md) {
+    display: flex;
+  }
 
   &__left {
     position: relative;

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -70,6 +70,9 @@
 .home-whop-grid {
   display: flex;
   gap: var(--spacing-md);
+  @include respond(sm) {
+    flex-direction: column;
+  }
 }
 
 .home-whop-column {
@@ -77,6 +80,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  @include respond(sm) {
+    width: 100%;
+  }
 }
 
 .whop-card-link {

--- a/src/styles/mobile-header.scss
+++ b/src/styles/mobile-header.scss
@@ -1,0 +1,32 @@
+@import './design-system';
+
+.mobile-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 50px;
+  background: var(--surface-color);
+  border-bottom: 1px solid var(--border-color);
+  display: none;
+  align-items: center;
+  padding: 0 var(--spacing-md);
+  z-index: 5000;
+
+  @include respond(md) {
+    display: flex;
+  }
+
+  + .main-content {
+    @include respond(md) {
+      padding-top: 50px;
+    }
+  }
+
+  &__menu {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--text-color);
+  }
+}

--- a/src/styles/page-loader.scss
+++ b/src/styles/page-loader.scss
@@ -1,0 +1,28 @@
+@import './design-system';
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.page-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+}
+
+.page-loader .spinner {
+  border: 4px solid var(--border-color);
+  border-top: 4px solid var(--primary-color);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  animation: spin 1s linear infinite;
+}

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -22,6 +22,22 @@
   top: 0;
   z-index: 40;
 
+  &__close {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--text-color);
+    position: absolute;
+    top: var(--spacing-md);
+    right: var(--spacing-md);
+    z-index: 1;
+
+    @include respond(md) {
+      display: block;
+    }
+  }
+
   &__logo {
     margin-bottom: var(--spacing-lg);
 
@@ -110,4 +126,17 @@
 
 .main-content.no-sidebar {
   margin-left: 0;
+}
+
+@include respond(md) {
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform var(--transition);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  .main-content {
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- define `--sidebar-width` in design system variables
- hide sidebar on small screens and show mobile menu
- hide bottom bar on large screens
- make home page whop grid stack on narrow widths
- add mobile header with hamburger menu
- add page loader overlay on route changes

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68794e8c5050832c93ffd8bd847d847e