### PR TITLE
Improve loader and theme

### DIFF
--- a/src/components/InitialLoader.jsx
+++ b/src/components/InitialLoader.jsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+import '../styles/initial-loader.scss';
+
+export default function InitialLoader() {
+  const [visible, setVisible] = useState(() => !window.localStorage.getItem('initialLoadDone'));
+
+  useEffect(() => {
+    if (!visible) return;
+    const timer = setTimeout(() => {
+      setVisible(false);
+      window.localStorage.setItem('initialLoadDone', 'true');
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [visible]);
+
+  if (!visible) return null;
+  return (
+    <div className="initial-loader">
+      <div className="initial-loader__spinner" />
+    </div>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import InitialLoader from './components/InitialLoader';
 import { ThemeProvider } from './context/ThemeContext';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './components/NotificationProvider';
@@ -21,6 +22,7 @@ root.render(
   <ThemeProvider>
     <AuthProvider>
       <NotificationProvider>
+        <InitialLoader />
         <App />
       </NotificationProvider>
     </AuthProvider>

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,7 @@
 @import './styles/bottombar';
 @import './styles/mobile-header';
 @import './styles/page-loader';
+@import './styles/initial-loader';
 
 // Global reset
 * {

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -48,8 +48,8 @@ body.theme-light {
 
 /* --- Dark theme (optional) --- */
 body.theme-dark {
-  --bg-color: #1c1c1c;
-  --surface-color: #2a2a2a;
+  --bg-color: #0e0e0e;
+  --surface-color: #181818;
 
   --text-color: #e0e0e0;
   --muted-color: #999999;
@@ -63,7 +63,7 @@ body.theme-dark {
   --error-hover: #cc4b55;
   --success-color: #2bb673;
 
-  --border-color: rgba(255, 255, 255, 0.1);
+  --border-color: rgba(255, 255, 255, 0.2);
   --shadow-soft: 0 4px 12px rgba(0, 0, 0, 0.15);
   --shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
   --sidebar-width: 60px;

--- a/src/styles/bottombar.scss
+++ b/src/styles/bottombar.scss
@@ -13,15 +13,21 @@
   background-color: rgba(233, 233, 233, 0.541);
   backdrop-filter: blur(5px);
   border-top: 1px solid var(--border-color);
-  display: none;
+  display: flex;
   align-items: center;
   padding: 0 var(--spacing-md);
   z-index: 9999;
   justify-content: space-between;
   box-shadow: var(--shadow-sm);
 
-  @include respond(md) {
-    display: flex;
+  @include respond(sm) {
+    flex-direction: column;
+    width: var(--sidebar-width);
+    height: 100vh;
+    top: 0;
+    bottom: 0 !important;
+    padding: var(--spacing-md) var(--spacing-sm);
+    justify-content: flex-start;
   }
 
   &__left {

--- a/src/styles/initial-loader.scss
+++ b/src/styles/initial-loader.scss
@@ -1,0 +1,31 @@
+@import './design-system';
+
+.initial-loader {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 15000;
+  animation: fadeOut 0.4s ease forwards;
+  animation-delay: 1.2s;
+}
+
+.initial-loader__spinner {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 4px solid var(--border-color);
+  border-top-color: var(--primary-color);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; visibility: hidden; }
+}


### PR DESCRIPTION
## Summary
- improve dark theme variables
- make bottom bar visible on desktop and responsive vertically on mobile
- add initial loading screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687953c70efc832c8412cf89730d5ff3