### PR TITLE
Improve mobile sidebar behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ const DiscordAccessSetup   = lazy(() => import("./pages/DiscordAccessSetup"));
 const App = () => {
   const { isLoggedIn } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
   return (
     <BrowserRouter>
       <PageLoader />
@@ -50,7 +51,7 @@ const App = () => {
                 {isLoggedIn && (
                   <>
                     <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                    <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                    <MobileHeader onMenu={toggleSidebar} />
                   </>
                 )}
                 <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}> 
@@ -68,7 +69,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Onboarding />
                   </main>
@@ -84,7 +85,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Setup />
                   </main>
@@ -98,7 +99,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <ChooseLink />
                   </main>
@@ -112,7 +113,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <FeaturesSetup />
                   </main>
@@ -126,7 +127,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <BannerSetup />
                   </main>
@@ -143,7 +144,7 @@ const App = () => {
                 {isLoggedIn && (
                   <>
                     <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                    <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                    <MobileHeader onMenu={toggleSidebar} />
                   </>
                 )}
                 <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}> 
@@ -161,7 +162,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Dashboard />
                   </main>
@@ -178,7 +179,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <SubmissionsOverview />
                   </main>
@@ -196,7 +197,7 @@ const App = () => {
                 {isLoggedIn && (
                   <>
                     <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                    <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                    <MobileHeader onMenu={toggleSidebar} />
                   </>
                 )}
                 <main className={`main-content${isLoggedIn ? '' : ' no-sidebar'}`}> 
@@ -214,7 +215,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Profile />
                   </main>
@@ -231,7 +232,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Balances />
                   </main>
@@ -248,7 +249,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Memberships />
                   </main>
@@ -265,7 +266,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <Payments />
                   </main>
@@ -282,7 +283,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <DiscordAccess />
                   </main>
@@ -299,7 +300,7 @@ const App = () => {
               <ProtectedRoute>
                 <div className="app-container">
                   <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-                  <MobileHeader onMenu={() => setSidebarOpen(true)} />
+                  <MobileHeader onMenu={toggleSidebar} />
                   <main className="main-content">
                     <DiscordAccessSetup />
                   </main>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -76,6 +76,7 @@ export default function Sidebar({ isOpen, onClose }) {
             <li className="sidebar__nav-item">
               <NavLink to="/" className="sidebar__link" end>
                 <FiHome className="sidebar__icon" />
+                <span className="sidebar__label">Home</span>
               </NavLink>
             </li>
 
@@ -90,6 +91,7 @@ export default function Sidebar({ isOpen, onClose }) {
                 }}
               >
                 <FiSearch className="sidebar__icon" />
+                <span className="sidebar__label">Search</span>
               </a>
             </li>
 
@@ -104,6 +106,7 @@ export default function Sidebar({ isOpen, onClose }) {
                 }}
               >
                 <FiMessageSquare className="sidebar__icon" />
+                <span className="sidebar__label">Chat</span>
               </a>
             </li>
 
@@ -111,6 +114,7 @@ export default function Sidebar({ isOpen, onClose }) {
             <li className="sidebar__nav-item">
               <NavLink to="/notifications" className="sidebar__link">
                 <FiBell className="sidebar__icon" />
+                <span className="sidebar__label">Notifications</span>
               </NavLink>
             </li>
 
@@ -118,6 +122,7 @@ export default function Sidebar({ isOpen, onClose }) {
             <li className="sidebar__nav-item">
               <NavLink to="/balances" className="sidebar__link">
                 <FiBarChart2 className="sidebar__icon" />
+                <span className="sidebar__label">Balances</span>
               </NavLink>
             </li>
 
@@ -125,6 +130,7 @@ export default function Sidebar({ isOpen, onClose }) {
             <li className="sidebar__nav-item">
               <NavLink to="/memberships" className="sidebar__link">
                 <FaUserShield className="sidebar__icon" />
+                <span className="sidebar__label">Memberships</span>
               </NavLink>
             </li>
 
@@ -132,6 +138,7 @@ export default function Sidebar({ isOpen, onClose }) {
             <li className="sidebar__nav-item">
               <NavLink to="/payments" className="sidebar__link">
                 <FaDollarSign className="sidebar__icon" />
+                <span className="sidebar__label">Payments</span>
               </NavLink>
             </li>
 
@@ -147,6 +154,7 @@ export default function Sidebar({ isOpen, onClose }) {
                 ) : (
                   <FiUser className="sidebar__icon" />
                 )}
+                <span className="sidebar__label">Profile</span>
               </NavLink>
             </li>
           </ul>

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -88,6 +88,13 @@
         transition: color var(--transition), transform var(--transition);
       }
 
+      .sidebar__label {
+        display: none;
+        margin-left: var(--spacing-sm);
+        color: var(--text-color);
+        font-size: 0.9rem;
+      }
+
       a.active .sidebar__icon {
         color: rgb(177, 97, 22);
       }
@@ -170,6 +177,26 @@
 
 .main-content.no-sidebar {
   margin-left: 0;
+}
+
+@include respond(sm) {
+  .sidebar {
+    width: 220px;
+  }
+  .sidebar__nav {
+    flex: none;
+    justify-content: flex-start;
+  }
+  .sidebar__nav-item {
+    justify-content: flex-start;
+    .sidebar__icon {
+      display: none;
+    }
+    .sidebar__label {
+      display: inline;
+      font-size: 1rem;
+    }
+  }
 }
 
 @include respond(md) {


### PR DESCRIPTION
## Summary
- toggle sidebar from burger button
- show text labels in the sidebar on small screens
- widen sidebar and move joined whops higher

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68795a9667f0832c8a3f17eb45426325