### PR TITLE
Enhance mobile layout

### DIFF
--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -8,6 +8,25 @@
   padding: 2rem;
 }
 
+@media (max-width: 768px) {
+  .dashboard-container {
+    padding: 1rem;
+  }
+
+  .filter-input {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .table-section {
+    overflow-x: auto;
+  }
+
+  .dashboard-table {
+    min-width: 600px;
+  }
+}
+
 .dashboard-title {
   margin-bottom: 1.5rem;
   font-size: 2rem;

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -223,6 +223,22 @@
   }
 }
 
+@include respond(xs) {
+  .whop-card {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .whop-content {
+    padding: var(--spacing-sm) 0;
+    align-items: center;
+  }
+  .whop-tag {
+    margin-left: 0;
+    margin-top: var(--spacing-sm);
+  }
+}
+
 /* Zlatá, stříbrná, bronzová medaile pro první 3 karty v prvním sloupci */
 .home-whop-column:first-child {
   .whop-card-link:nth-child(1) .whop-card {

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -599,3 +599,13 @@
     margin-bottom: var(--spacing-md);
   }
 }
+
+@media (max-width: 480px) {
+  .member-sidebar .nav-button {
+    font-size: 0.875rem;
+    padding: var(--spacing-xxs) var(--spacing-xs);
+  }
+  .member-banner {
+    height: 8rem;
+  }
+}

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -821,6 +821,15 @@
   }
 }
 
+@media (max-width: 480px) {
+  .whop-banner {
+    height: 140px;
+  }
+  .whop-content {
+    padding: 0 var(--spacing-sm);
+  }
+}
+
 .owner-text-menu {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- improve dashboard responsiveness
- tweak member sidebar for small screens
- better owner view spacing on phones
- adjust home cards for extra small devices

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68795c92ed00832c820090d64b1a6712