### PR TITLE
Improve mobile view

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMode.jsx
+++ b/src/pages/WhopDashboard/components/MemberMode.jsx
@@ -1,6 +1,6 @@
 // src/pages/WhopDashboard/components/MemberMode.jsx
 
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import MemberSidebar from "./MemberSidebar";
 import MemberMain from "./MemberMain";
 import SubmissionPanel from "./SubmissionPanel";
@@ -18,6 +18,35 @@ export default function MemberMode({
 }) {
   // State for the selected campaign (when the user clicks in the "Earn" tab)
   const [selectedCampaign, setSelectedCampaign] = useState(null);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || window.innerWidth > 768) return;
+    let startX = null;
+    const start = (e) => {
+      startX = e.touches[0].clientX;
+    };
+    const end = (e) => {
+      if (startX === null) return;
+      const diff = e.changedTouches[0].clientX - startX;
+      if (!mobileSidebarOpen && diff > 50) {
+        setMobileSidebarOpen(true);
+        window.navigator.vibrate?.(20);
+      } else if (mobileSidebarOpen && diff < -50) {
+        setMobileSidebarOpen(false);
+        window.navigator.vibrate?.(20);
+      }
+      startX = null;
+    };
+    container.addEventListener('touchstart', start);
+    container.addEventListener('touchend', end);
+    return () => {
+      container.removeEventListener('touchstart', start);
+      container.removeEventListener('touchend', end);
+    };
+  }, [mobileSidebarOpen]);
 
   // Callback to return from the submission panel
   const handleBackFromSubmission = () => {
@@ -27,7 +56,7 @@ export default function MemberMode({
   // If a campaign is selected, render the SubmissionPanel
   if (selectedCampaign) {
     return (
-      <div className="member-container">
+      <div className={`member-container${mobileSidebarOpen ? ' sidebar-open' : ''}`} ref={containerRef}>
         <MemberSidebar
           whopData={whopData}
           activeTab={activeTab}
@@ -36,6 +65,7 @@ export default function MemberMode({
           handleLeave={handleLeave}
           showBackButton={true}
           onBack={handleBackFromSubmission}
+          isMobileOpen={mobileSidebarOpen}
         />
         <SubmissionPanel
           whopData={whopData}
@@ -48,7 +78,7 @@ export default function MemberMode({
 
   // Otherwise, render the standard mode: Sidebar + Main content
   return (
-    <div className="member-container">
+    <div className={`member-container${mobileSidebarOpen ? ' sidebar-open' : ''}`} ref={containerRef}>
       <MemberSidebar
         whopData={whopData}
         activeTab={activeTab}
@@ -56,6 +86,7 @@ export default function MemberMode({
         memberLoading={memberLoading}
         handleLeave={handleLeave}
         showBackButton={false}
+        isMobileOpen={mobileSidebarOpen}
       />
       <MemberMain
         whopData={whopData}

--- a/src/pages/WhopDashboard/components/MemberSidebar.jsx
+++ b/src/pages/WhopDashboard/components/MemberSidebar.jsx
@@ -17,10 +17,11 @@ export default function MemberSidebar({
   activeTab,
   setActiveTab,
   memberLoading,
-  handleLeave
+  handleLeave,
+  isMobileOpen = false
 }) {
   return (
-    <div className="member-sidebar">
+    <div className={`member-sidebar${isMobileOpen ? ' open' : ''}`}>
       <div className="member-banner">
         {whopData.banner_url ? (
           <img

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -72,6 +72,7 @@
   gap: var(--spacing-md);
   @include respond(sm) {
     flex-direction: column;
+    align-items: center;
   }
 }
 
@@ -82,6 +83,7 @@
   gap: var(--spacing-md);
   @include respond(sm) {
     width: 100%;
+    align-items: center;
   }
 }
 
@@ -228,6 +230,8 @@
     flex-direction: column;
     align-items: center;
     text-align: center;
+    width: 100%;
+    max-width: 400px;
   }
   .whop-content {
     padding: var(--spacing-sm) 0;

--- a/src/styles/landingpage.scss
+++ b/src/styles/landingpage.scss
@@ -254,3 +254,10 @@
     font-size: 1.6rem;
   }
 }
+
+@media (max-width: 480px) {
+  .reviews-grid,
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -581,13 +581,26 @@
 
 @media (max-width: 768px) {
   .member-sidebar {
-    width: 100%;
-    height: auto;
-    position: relative;
-    flex-direction: column;
+    width: 16rem;
+    max-width: 80%;
+    height: 100vh;
+    position: fixed;
+    left: 0;
+    top: 0;
+    transform: translateX(-100%);
+    transition: transform var(--transition);
+    z-index: 50;
+  }
+  .member-sidebar.open {
+    transform: translateX(0);
+  }
+  .member-container.sidebar-open .member-sidebar {
+    transform: translateX(0);
   }
   .member-main {
-    margin-top: var(--spacing-lg);
+    margin-top: 0;
+    flex: 1;
+    padding: var(--spacing-lg);
   }
 
   .course-viewer {
@@ -607,5 +620,8 @@
   }
   .member-banner {
     height: 8rem;
+  }
+  .member-sidebar {
+    width: 14rem;
   }
 }


### PR DESCRIPTION
## Summary
- improve mobile swipe to open sidebar in Member view
- center whop cards on small screens
- adjust landing page grids for small devices
- slide sidebar on mobile with CSS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a90c6ca20832cb3db85e902d91952