### PR TITLE
Improve mobile sidebar and home cards

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMode.jsx
+++ b/src/pages/WhopDashboard/components/MemberMode.jsx
@@ -72,6 +72,10 @@ export default function MemberMode({
           campaign={selectedCampaign}
           onBack={handleBackFromSubmission}
         />
+        <div
+          className={`sidebar-overlay${mobileSidebarOpen ? ' visible' : ''}`}
+          onClick={() => setMobileSidebarOpen(false)}
+        />
       </div>
     );
   }
@@ -96,6 +100,10 @@ export default function MemberMode({
         campaignsError={campaignsError}
         onSelectCampaign={setSelectedCampaign}
         setWhopData={setWhopData}
+      />
+      <div
+        className={`sidebar-overlay${mobileSidebarOpen ? ' visible' : ''}`}
+        onClick={() => setMobileSidebarOpen(false)}
       />
     </div>
   );

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -7,6 +7,12 @@
   background: var(--bg-color);
 }
 
+@include respond(md) {
+  .main-content {
+    margin-left: 0;
+  }
+}
+
 .home-header {
   text-align: center;
   margin-bottom: var(--spacing-md);
@@ -97,7 +103,7 @@
   align-items: flex-start;
   background: var(--surface-color);
   border: 1px solid var(--border-color);
-  border-radius: 999px;
+  border-radius: var(--radius-lg);
   padding: var(--spacing-sm) var(--spacing-md);
   box-shadow: var(--shadow-soft);
   min-height: 100px;
@@ -262,7 +268,7 @@
 .whop-card-skeleton {
   height: 100px;
   background: var(--border-color);
-  border-radius: 999px;
+  border-radius: var(--radius-lg);
   animation: pulse 1.2s infinite ease-in-out;
 }
 

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -591,6 +591,10 @@
     transition: transform var(--transition);
     z-index: 50;
   }
+
+  .whop-features-grid {
+    grid-template-columns: 1fr;
+  }
   .member-sidebar.open {
     transform: translateX(0);
   }
@@ -601,6 +605,22 @@
     margin-top: 0;
     flex: 1;
     padding: var(--spacing-lg);
+  }
+
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    transition: opacity var(--transition);
+    pointer-events: none;
+    z-index: 40;
+  }
+
+  .member-container.sidebar-open .sidebar-overlay {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .course-viewer {


### PR DESCRIPTION
## Summary
- adjust home card shapes for consistent look
- remove margin-left on small screens
- support sidebar overlay when opened on mobile
- allow features grid to stack vertically

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a9574ae38832c809d18c7d7bb974a