### PR TITLE
Fix mobile member layout overflow

### DIFF
--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -4,6 +4,7 @@
   height: calc(100vh - var(--bottombar-height));
   background: var(--bg-color);
   position: relative;
+  overflow-x: hidden;
 }
 
 .member-sidebar {
@@ -134,7 +135,6 @@
 .member-main {
   flex: 1;
   min-width: 0;
-  width: 100%;
   background: var(--bg-color);
   padding: var(--spacing-lg);
   overflow-y: auto;
@@ -609,7 +609,6 @@
     margin-top: 0;
     flex: 1;
     min-width: 0;
-    width: 100%;
     padding: var(--spacing-lg);
   }
 


### PR DESCRIPTION
## Summary
- prevent horizontal scroll in member view
- ensure main area flexes correctly without fixed width

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a9b814578832c9e4604e90b7e73c1