### PR TITLE
Optimize loaders and skeletons

### DIFF
--- a/src/components/DashboardSkeleton.jsx
+++ b/src/components/DashboardSkeleton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '../styles/dashboard-skeleton.scss';
+
+export default function DashboardSkeleton() {
+  return (
+    <div className="dashboard-skeleton">
+      <div className="skeleton-line" style={{ width: '40%' }} />
+      <div className="skeleton-box" />
+      <div className="skeleton-box" />
+    </div>
+  );
+}

--- a/src/components/InitialLoader.jsx
+++ b/src/components/InitialLoader.jsx
@@ -1,18 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import '../styles/initial-loader.scss';
-import logo from './../assets/load.png'
+import logo from './../assets/load.png';
 
 export default function InitialLoader() {
-  const [visible, setVisible] = useState(() => !window.localStorage.getItem('initialLoadDone'));
+  const isMobile = /Mobi|Android/i.test(navigator.userAgent);
+  const isPWA = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+  const isMobilePWA = isMobile && isPWA;
+  const showOnce = !isMobilePWA;
+  const initialVisible = showOnce ? !window.localStorage.getItem('initialLoadDone') : isMobilePWA;
+  const [visible, setVisible] = useState(initialVisible);
 
   useEffect(() => {
     if (!visible) return;
     const timer = setTimeout(() => {
       setVisible(false);
-      window.localStorage.setItem('initialLoadDone', 'true');
+      if (showOnce) {
+        window.localStorage.setItem('initialLoadDone', 'true');
+      }
     }, 3000);
     return () => clearTimeout(timer);
-  }, [visible]);
+  }, [visible, showOnce]);
 
   if (!visible) return null;
   return (

--- a/src/components/PageLoader.jsx
+++ b/src/components/PageLoader.jsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import '../styles/page-loader.scss';
-import logo from './../assets/load.png'
+import logo from './../assets/load.png';
+import { useLoading } from '../context/LoadingContext';
 
 export default function PageLoader() {
   const location = useLocation();
-  const [loading, setLoading] = useState(false);
+  const { loading, showLoader, hideLoader } = useLoading();
 
   useEffect(() => {
-    setLoading(true);
-    const timeout = setTimeout(() => setLoading(false), 800);
+    showLoader();
+    const timeout = setTimeout(() => hideLoader(), 300);
     return () => clearTimeout(timeout);
-  }, [location]);
+  }, [location, showLoader, hideLoader]);
 
   if (!loading) return null;
   return (

--- a/src/context/LoadingContext.jsx
+++ b/src/context/LoadingContext.jsx
@@ -1,0 +1,18 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const LoadingContext = createContext();
+
+export const LoadingProvider = ({ children }) => {
+  const [loading, setLoading] = useState(false);
+
+  const showLoader = useCallback(() => setLoading(true), []);
+  const hideLoader = useCallback(() => setLoading(false), []);
+
+  return (
+    <LoadingContext.Provider value={{ loading, showLoader, hideLoader }}>
+      {children}
+    </LoadingContext.Provider>
+  );
+};
+
+export const useLoading = () => useContext(LoadingContext);

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import InitialLoader from './components/InitialLoader';
 import { ThemeProvider } from './context/ThemeContext';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './components/NotificationProvider';
+import { LoadingProvider } from './context/LoadingContext';
 
 import './index.scss';
 import './styles/App.scss';
@@ -21,10 +22,12 @@ const root = createRoot(container);
 root.render(
   <ThemeProvider>
     <AuthProvider>
-      <NotificationProvider>
-        <InitialLoader />
-        <App />
-      </NotificationProvider>
+      <LoadingProvider>
+        <NotificationProvider>
+          <InitialLoader />
+          <App />
+        </NotificationProvider>
+      </LoadingProvider>
     </AuthProvider>
   </ThemeProvider>
 );

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,6 +6,8 @@
 @import './styles/mobile-header';
 @import './styles/page-loader';
 @import './styles/initial-loader';
+@import './styles/skeleton';
+@import './styles/dashboard-skeleton';
 
 // Global reset
 * {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -16,6 +16,7 @@ import AffiliateDefaultsSection from "./WhopDashboard/components/AffiliateDefaul
 import fetchAffiliateLinks from "./WhopDashboard/fetchAffiliateLinks";
 import handleUpdateAffiliateLink from "./WhopDashboard/handleUpdateAffiliateLink";
 import "../styles/dashboard.scss";
+import DashboardSkeleton from "../components/DashboardSkeleton";
 
 export default function Dashboard() {
   const { showNotification, showConfirm } = useNotifications();
@@ -491,7 +492,7 @@ export default function Dashboard() {
   }, [filteredPayments, currentPage]);
 
   if (!dataLoaded) {
-    return <p className="dashboard-loading">Loading dashboard…</p>;
+    return <DashboardSkeleton />;
   }
 
   return (

--- a/src/styles/dashboard-skeleton.scss
+++ b/src/styles/dashboard-skeleton.scss
@@ -1,0 +1,6 @@
+.dashboard-skeleton {
+  padding: 1rem;
+}
+.dashboard-skeleton .skeleton-line {
+  width: 60%;
+}

--- a/src/styles/page-loader.scss
+++ b/src/styles/page-loader.scss
@@ -9,16 +9,22 @@
 .page-loader {
   position: fixed;
   inset: 0;
-  background: rgba(240, 240, 240, 0.8);
+  background: rgba(240, 240, 240, 0.6);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 10000;
-  backdrop-filter: blur(5px);
+  backdrop-filter: blur(3px);
+  animation: fadeOut 0.2s ease forwards;
+  animation-delay: 0.25s;
 }
 
 .page-loader__image {
-  width: 200px;
-  height: 200px;
-  animation: pulse 1.2s ease-in-out infinite;
+  width: 120px;
+  height: 120px;
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; visibility: hidden; }
 }

--- a/src/styles/skeleton.scss
+++ b/src/styles/skeleton.scss
@@ -1,0 +1,21 @@
+.skeleton-line,
+.skeleton-box {
+  background: var(--border-color);
+  animation: pulse 1.2s ease-in-out infinite;
+  border-radius: var(--radius-base);
+}
+
+.skeleton-line {
+  height: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton-box {
+  height: 150px;
+  margin-bottom: 1rem;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary
- make page loader use global LoadingContext for quick animations
- show splash on mobile PWA while only first load on desktop
- add global LoadingProvider
- introduce generic skeleton styles
- add skeleton screen for dashboard
- tweak page loader styles

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687ab6d3bf04832c9b5d8204c8a99225