### PR TITLE
Improve loading UX

### DIFF
--- a/src/components/InitialLoader.jsx
+++ b/src/components/InitialLoader.jsx
@@ -1,27 +1,32 @@
 import React, { useEffect, useState } from 'react';
 import '../styles/initial-loader.scss';
-import logo from './../assets/load.png'
+import logo from './../assets/load.png';
 
 export default function InitialLoader() {
-  const [visible, setVisible] = useState(() => !window.localStorage.getItem('initialLoadDone'));
+  const isStandalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    window.navigator.standalone === true;
+
+  const [visible, setVisible] = useState(() => {
+    if (isStandalone) return true;
+    return !window.localStorage.getItem('initialLoadDone');
+  });
 
   useEffect(() => {
-    if (!visible) return;
+    if (!visible) return undefined;
     const timer = setTimeout(() => {
       setVisible(false);
-      window.localStorage.setItem('initialLoadDone', 'true');
-    }, 3000);
+      if (!isStandalone) {
+        window.localStorage.setItem('initialLoadDone', 'true');
+      }
+    }, 2000);
     return () => clearTimeout(timer);
-  }, [visible]);
+  }, [visible, isStandalone]);
 
   if (!visible) return null;
   return (
     <div className="initial-loader">
-      <img
-        src={logo} // nahraď svou cestou k PNG
-        alt="Loading..."
-        className="initial-loader__image"
-      />
+      <img src={logo} alt="Loading..." className="initial-loader__image" />
     </div>
   );
 }

--- a/src/components/PageLoader.jsx
+++ b/src/components/PageLoader.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import '../styles/page-loader.scss';
-import logo from './../assets/load.png'
+import logo from './../assets/load.png';
 
 export default function PageLoader() {
   const location = useLocation();
@@ -9,7 +9,7 @@ export default function PageLoader() {
 
   useEffect(() => {
     setLoading(true);
-    const timeout = setTimeout(() => setLoading(false), 800);
+    const timeout = setTimeout(() => setLoading(false), 300);
     return () => clearTimeout(timeout);
   }, [location]);
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -491,7 +491,13 @@ export default function Dashboard() {
   }, [filteredPayments, currentPage]);
 
   if (!dataLoaded) {
-    return <p className="dashboard-loading">Loading dashboard…</p>;
+    return (
+      <div className="dashboard-skeleton">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="dashboard-skeleton-card" />
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -177,6 +177,26 @@ button.btn-remove-mod:hover {
   color: var(--muted-color);
 }
 
+/* Skeletons shown while dashboard loads */
+.dashboard-skeleton {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+}
+
+.dashboard-skeleton-card {
+  height: 100px;
+  background: var(--border-color);
+  border-radius: var(--radius-base);
+  animation: dashboardPulse 1.5s infinite ease-in-out;
+}
+
+@keyframes dashboardPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
 /* Pagination */
 .pagination {
   display: flex;


### PR DESCRIPTION
## Summary
- add PWA splash logic to `InitialLoader`
- speed up `PageLoader`
- show skeleton while dashboard loads

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aba3d139c832c8e96b2aef4829bb3