### PR TITLE
Refine loaders and add skeletons

### DIFF
--- a/src/components/InitialLoader.jsx
+++ b/src/components/InitialLoader.jsx
@@ -3,16 +3,23 @@ import '../styles/initial-loader.scss';
 import logo from './../assets/load.png'
 
 export default function InitialLoader() {
-  const [visible, setVisible] = useState(() => !window.localStorage.getItem('initialLoadDone'));
+  const isStandalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    window.navigator.standalone === true;
+  const [visible, setVisible] = useState(() =>
+    isStandalone ? true : !window.localStorage.getItem('initialLoadDone')
+  );
 
   useEffect(() => {
     if (!visible) return;
     const timer = setTimeout(() => {
       setVisible(false);
-      window.localStorage.setItem('initialLoadDone', 'true');
-    }, 3000);
+      if (!isStandalone) {
+        window.localStorage.setItem('initialLoadDone', 'true');
+      }
+    }, 2000);
     return () => clearTimeout(timer);
-  }, [visible]);
+  }, [visible, isStandalone]);
 
   if (!visible) return null;
   return (

--- a/src/components/PageLoader.jsx
+++ b/src/components/PageLoader.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import '../styles/page-loader.scss';
-import logo from './../assets/load.png'
 
 export default function PageLoader() {
   const location = useLocation();
@@ -16,11 +15,7 @@ export default function PageLoader() {
   if (!loading) return null;
   return (
     <div className="page-loader">
-      <img
-        src={logo} // nahraď správnou cestou
-        alt="Loading..."
-        className="page-loader__image"
-      />
+      <div className="spinner" />
     </div>
   );
 }

--- a/src/components/SubmissionsSkeleton.jsx
+++ b/src/components/SubmissionsSkeleton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '../styles/submissions-skeleton.scss';
+
+export default function SubmissionsSkeleton() {
+  return (
+    <div className="submissions-skeleton">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="skeleton-box" />
+      ))}
+    </div>
+  );
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,6 +6,7 @@
 @import './styles/mobile-header';
 @import './styles/page-loader';
 @import './styles/initial-loader';
+@import './styles/skeleton';
 
 // Global reset
 * {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 // src/pages/Dashboard.jsx
 
 import React, { useEffect, useState, useMemo } from "react";
+import DashboardSkeleton from "../components/DashboardSkeleton";
 import { useNotifications } from "../components/NotificationProvider";
 import {
   LineChart,
@@ -491,7 +492,7 @@ export default function Dashboard() {
   }, [filteredPayments, currentPage]);
 
   if (!dataLoaded) {
-    return <p className="dashboard-loading">Loading dashboard…</p>;
+    return <DashboardSkeleton />;
   }
 
   return (

--- a/src/pages/SubmissionsOverview.jsx
+++ b/src/pages/SubmissionsOverview.jsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import SubmissionCard from "../components/SubmissionCard";
 import RejectModal from "../components/RejectModal";
 import ApproveModal from "../components/ApproveModal";
+import SubmissionsSkeleton from "../components/SubmissionsSkeleton";
 import "../styles/submissions-overview.scss";
 
 export default function SubmissionsOverview() {
@@ -51,7 +52,7 @@ export default function SubmissionsOverview() {
     setModalType(null);
   };
 
-  if (loading) return <div className="loading">Loading…</div>;
+  if (loading) return <SubmissionsSkeleton />;
   if (error) return <div className="error">Error: {error}</div>;
 
   return (

--- a/src/styles/page-loader.scss
+++ b/src/styles/page-loader.scss
@@ -1,9 +1,8 @@
 @import './design-system';
 
-@keyframes pulse {
-  0%   { transform: scale(1); opacity: 1; }
-  50%  { transform: scale(1.1); opacity: 0.75; }
-  100% { transform: scale(1); opacity: 1; }
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 .page-loader {
@@ -17,8 +16,11 @@
   backdrop-filter: blur(5px);
 }
 
-.page-loader__image {
-  width: 200px;
-  height: 200px;
-  animation: pulse 1.2s ease-in-out infinite;
+.spinner {
+  border: 4px solid var(--border-color);
+  border-top: 4px solid var(--primary-color);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  animation: spin 0.8s linear infinite;
 }

--- a/src/styles/submissions-skeleton.scss
+++ b/src/styles/submissions-skeleton.scss
@@ -1,0 +1,5 @@
+@import './skeleton';
+
+.submissions-skeleton {
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- detect PWA mode and show `InitialLoader` every launch when installed
- simplify `PageLoader` with a small spinner
- import skeleton styles globally
- show `DashboardSkeleton` and new `SubmissionsSkeleton` while data loads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ac014eb80832c9611da8c0118e994