### PR TITLE
Enable swipe toggle for OwnerTextMenu

### DIFF
--- a/src/pages/WhopDashboard/components/OwnerTextMenu.jsx
+++ b/src/pages/WhopDashboard/components/OwnerTextMenu.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import "../../../styles/whop-dashboard/_owner.scss";
 
 export default function OwnerTextMenu({
@@ -17,6 +17,32 @@ export default function OwnerTextMenu({
   editLandingTexts,
   setEditLandingTexts,
 }) {
+  const [isOpen, setIsOpen] = useState(true);
+  const touchStartXRef = useRef(null);
+
+  useEffect(() => {
+    const handleTouchStart = (e) => {
+      touchStartXRef.current = e.touches[0].clientX;
+    };
+    const handleTouchEnd = (e) => {
+      if (touchStartXRef.current === null) return;
+      const deltaX = e.changedTouches[0].clientX - touchStartXRef.current;
+      if (Math.abs(deltaX) > 50) {
+        if (deltaX > 0 && isOpen) {
+          setIsOpen(false);
+        } else if (deltaX < 0 && !isOpen) {
+          setIsOpen(true);
+        }
+      }
+      touchStartXRef.current = null;
+    };
+    document.addEventListener("touchstart", handleTouchStart);
+    document.addEventListener("touchend", handleTouchEnd);
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [isOpen]);
   const handleSocialChange = (key, value) => {
     setEditSocials((prev) => ({ ...prev, [key]: value }));
   };
@@ -46,7 +72,7 @@ export default function OwnerTextMenu({
   };
 
   return (
-    <div className="owner-text-menu">
+    <div className={`owner-text-menu${isOpen ? "" : " closed"}`}>
       <h3>Edit Text Content</h3>
       <textarea
         className="otm-textarea"

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -842,6 +842,12 @@
   overflow-y: auto;
   box-shadow: var(--shadow-soft);
   z-index: 1000;
+  transform: translateX(0);
+  transition: transform var(--transition);
+
+  &.closed {
+    transform: translateX(100%);
+  }
 
   h3,
   h4 {


### PR DESCRIPTION
## Summary
- allow toggling the owner text menu via swipe gestures on mobile
- animate the menu in/out with CSS transform

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687ac272b604832cb78fb093ed654868