### PR TITLE
Add mobile swipe behavior to owner menu

### DIFF
--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -1,6 +1,6 @@
 // src/pages/WhopDashboard/components/OwnerMode.jsx
 
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { FaArrowLeft } from "react-icons/fa";
 import "../../../styles/whop-dashboard/_owner.scss";
 
@@ -82,8 +82,41 @@ export default function OwnerMode({
 }) {
   if (!whopData) return null;
 
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(true);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || window.innerWidth > 768) return;
+    let startX = null;
+    const start = (e) => {
+      startX = e.touches[0].clientX;
+    };
+    const end = (e) => {
+      if (startX === null) return;
+      const diff = e.changedTouches[0].clientX - startX;
+      if (!mobileMenuOpen && diff < -50) {
+        setMobileMenuOpen(true);
+        window.navigator.vibrate?.(20);
+      } else if (mobileMenuOpen && diff > 50) {
+        setMobileMenuOpen(false);
+        window.navigator.vibrate?.(20);
+      }
+      startX = null;
+    };
+    container.addEventListener("touchstart", start);
+    container.addEventListener("touchend", end);
+    return () => {
+      container.removeEventListener("touchstart", start);
+      container.removeEventListener("touchend", end);
+    };
+  }, [mobileMenuOpen]);
+
   return (
-    <div className="whop-container">
+    <div
+      className={`whop-container${mobileMenuOpen ? ' menu-open' : ''}`}
+      ref={containerRef}
+    >
       {/* Show "Back" button only in edit mode */}
       {isEditing && (
         <button
@@ -125,6 +158,7 @@ export default function OwnerMode({
           setEditFaq={setEditFaq}
           editLandingTexts={editLandingTexts}
           setEditLandingTexts={setEditLandingTexts}
+          isMobileOpen={mobileMenuOpen}
         />
       )}
 
@@ -224,6 +258,10 @@ export default function OwnerMode({
           fetchCampaigns={fetchCampaigns}
         />
       )}
+      <div
+        className={`sidebar-overlay${mobileMenuOpen ? ' visible' : ''}`}
+        onClick={() => setMobileMenuOpen(false)}
+      />
     </div>
   );
 }

--- a/src/pages/WhopDashboard/components/OwnerTextMenu.jsx
+++ b/src/pages/WhopDashboard/components/OwnerTextMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React from "react";
 import "../../../styles/whop-dashboard/_owner.scss";
 
 export default function OwnerTextMenu({
@@ -16,33 +16,8 @@ export default function OwnerTextMenu({
   setEditFaq,
   editLandingTexts,
   setEditLandingTexts,
+  isMobileOpen,
 }) {
-  const [isOpen, setIsOpen] = useState(true);
-  const touchStartXRef = useRef(null);
-
-  useEffect(() => {
-    const handleTouchStart = (e) => {
-      touchStartXRef.current = e.touches[0].clientX;
-    };
-    const handleTouchEnd = (e) => {
-      if (touchStartXRef.current === null) return;
-      const deltaX = e.changedTouches[0].clientX - touchStartXRef.current;
-      if (Math.abs(deltaX) > 50) {
-        if (deltaX > 0 && isOpen) {
-          setIsOpen(false);
-        } else if (deltaX < 0 && !isOpen) {
-          setIsOpen(true);
-        }
-      }
-      touchStartXRef.current = null;
-    };
-    document.addEventListener("touchstart", handleTouchStart);
-    document.addEventListener("touchend", handleTouchEnd);
-    return () => {
-      document.removeEventListener("touchstart", handleTouchStart);
-      document.removeEventListener("touchend", handleTouchEnd);
-    };
-  }, [isOpen]);
   const handleSocialChange = (key, value) => {
     setEditSocials((prev) => ({ ...prev, [key]: value }));
   };
@@ -72,7 +47,7 @@ export default function OwnerTextMenu({
   };
 
   return (
-    <div className={`owner-text-menu${isOpen ? "" : " closed"}`}>
+    <div className={`owner-text-menu${isMobileOpen ? "" : " closed"}`}>
       <h3>Edit Text Content</h3>
       <textarea
         className="otm-textarea"

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -819,6 +819,58 @@
 .member-main {
     margin-top: var(--spacing-lg);
   }
+
+  .whop-container {
+    display: block;
+    min-height: 100vh;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    background: var(--bg-color);
+
+    &.menu-open {
+      display: flex;
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+  }
+
+  .owner-text-menu {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    transform: translateX(100%);
+    visibility: hidden;
+    opacity: 0;
+    background: var(--surface-color);
+    z-index: 50;
+    transition: transform var(--transition), visibility var(--transition), opacity var(--transition);
+  }
+
+  .whop-container.menu-open .owner-text-menu {
+    transform: translateX(0);
+    visibility: visible;
+    opacity: 1;
+  }
+
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    pointer-events: none;
+    z-index: 40;
+    transition: opacity var(--transition);
+  }
+
+  .whop-container.menu-open .sidebar-overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 @media (max-width: 480px) {
@@ -830,75 +882,28 @@
   }
 }
 
-.owner-text-menu {
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: 18rem;
-  height: 100%;
-  background: var(--surface-color);
-  border-left: 1px solid var(--border-color);
-  padding: var(--spacing-md);
-  overflow-y: auto;
-  box-shadow: var(--shadow-soft);
-  z-index: 1000;
-  transform: translateX(0);
-  transition: transform var(--transition);
-
-  &.closed {
-    transform: translateX(100%);
-  }
-
-  h3,
-  h4 {
-    color: var(--text-color);
-    margin-top: var(--spacing-sm);
-    margin-bottom: var(--spacing-sm);
-    text-align: center;
-  }
-
-  .otm-input,
-  .otm-textarea {
-    width: 100%;
-    padding: var(--spacing-xs);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-base);
+@media (min-width: 769px) {
+  .owner-text-menu {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 18rem;
+    height: 100%;
     background: var(--surface-color);
-    color: var(--text-color);
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .otm-subgroup {
-    margin-bottom: var(--spacing-sm);
-  }
-
-  .otm-remove,
-  .otm-add {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-    background: var(--primary-color);
-    color: #fff;
-    border: none;
-    border-radius: var(--radius-lg);
-    padding: var(--spacing-xs) var(--spacing-sm);
-    font-size: 0.8rem;
-    cursor: pointer;
+    border-left: 1px solid var(--border-color);
+    padding: var(--spacing-md);
+    overflow-y: auto;
     box-shadow: var(--shadow-soft);
-    transition: background var(--transition), transform var(--transition);
-    margin-top: var(--spacing-xs);
-  }
+    z-index: 1000;
+    transform: translateX(0);
+    transition: transform var(--transition);
 
-  .otm-remove {
-    background: var(--error-color);
-  }
-
-  .otm-remove:hover,
-  .otm-add:hover {
-    background: var(--primary-hover);
-    transform: translateY(-1px);
+    &.closed {
+      transform: translateX(100%);
+    }
   }
 }
+
 
 .course-section {
   margin-bottom: var(--spacing-lg);


### PR DESCRIPTION
## Summary
- enable swipe support for Owner text menu
- manage Owner menu state in `OwnerMode`
- show overlay when Owner menu is open
- adjust mobile styles for owner text menu

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac413fcfc832c9910fbab50ce27c3