### PR TITLE
Fix conditional hooks in OwnerMode

### DIFF
--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -80,8 +80,6 @@ export default function OwnerMode({
   showDiscordSetup,
   setShowDiscordSetup,
 }) {
-  if (!whopData) return null;
-
   const [mobileMenuOpen, setMobileMenuOpen] = useState(true);
   const containerRef = useRef(null);
 
@@ -111,6 +109,8 @@ export default function OwnerMode({
       container.removeEventListener("touchend", end);
     };
   }, [mobileMenuOpen]);
+
+  if (!whopData) return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- ensure React hooks in `OwnerMode` are unconditionally called

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687ac7386540832c8216ceb0c2886e8e