### PR TITLE
Fix mobile sidebar swipe

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMode.jsx
+++ b/src/pages/WhopDashboard/components/MemberMode.jsx
@@ -27,23 +27,37 @@ export default function MemberMode({
     let startX = null;
     const start = (e) => {
       startX = e.touches[0].clientX;
+      const width = container.clientWidth;
+      // Ignore system back swipe by not starting from the very edge
+      if (startX < 20 || startX > width - 20) {
+        startX = null;
+      }
     };
-    const end = (e) => {
+    const move = (e) => {
       if (startX === null) return;
-      const diff = e.changedTouches[0].clientX - startX;
+      const diff = e.touches[0].clientX - startX;
       if (!mobileSidebarOpen && diff > 50) {
         setMobileSidebarOpen(true);
         window.navigator.vibrate?.(20);
+        startX = null;
       } else if (mobileSidebarOpen && diff < -50) {
         setMobileSidebarOpen(false);
         window.navigator.vibrate?.(20);
+        startX = null;
       }
+      if (startX === null) {
+        e.preventDefault();
+      }
+    };
+    const end = () => {
       startX = null;
     };
-    container.addEventListener('touchstart', start);
+    container.addEventListener('touchstart', start, { passive: false });
+    container.addEventListener('touchmove', move, { passive: false });
     container.addEventListener('touchend', end);
     return () => {
       container.removeEventListener('touchstart', start);
+      container.removeEventListener('touchmove', move);
       container.removeEventListener('touchend', end);
     };
   }, [mobileSidebarOpen]);

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -14,6 +14,7 @@ html, body {
   background-color: var(--bg-color);
   color: var(--text-color);
   overflow-x: hidden;
+  overscroll-behavior-x: none; // prevent browser back swipe on supported browsers
 }
 
 *,

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -5,6 +5,7 @@
   background: var(--bg-color);
   position: relative;
   overflow-x: hidden;
+  touch-action: pan-y; // allow vertical scroll but prevent horizontal navigation
 }
 
 .member-sidebar {


### PR DESCRIPTION
## Summary
- prevent overscroll on mobile to reduce navigation gestures
- disable horizontal pan in mobile member container
- tweak swipe handler to ignore edge swipes and use touchmove

## Testing
- `npm test -- --passWithNoTests --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b8918aecc832cb2def678a9521030