### PR TITLE
Fix Discord module visibility

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -268,7 +268,7 @@ export default function MemberMain({
       )}
 
       {/* DISCORD */}
-      {activeTab === "Discord" && whopData.modules?.discord_access && (
+      {activeTab === "Discord" && Boolean(whopData.modules?.discord_access) && (
         <div className="member-tab-content">
           <h3 className="member-subtitle">Discord Access</h3>
           <p className="member-text">

--- a/src/pages/WhopDashboard/components/MemberSidebar.jsx
+++ b/src/pages/WhopDashboard/components/MemberSidebar.jsx
@@ -70,7 +70,7 @@ export default function MemberSidebar({
             <FaDollarSign /> Affiliate
           </button>
         )}
-        {whopData.modules?.discord_access && (
+        {Boolean(whopData.modules?.discord_access) && (
           <button
             className={`nav-button ${activeTab === "Discord" ? "active" : ""}`}
             onClick={() => setActiveTab("Discord")}

--- a/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
+++ b/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
@@ -43,7 +43,7 @@ export default function OwnerActionButtons({
           >
             Cancel
           </button>
-          {whopData.modules?.discord_access && (
+          {Boolean(whopData.modules?.discord_access) && (
             <button
               className="whop-discord-btn"
               onClick={() => setShowDiscordSetup(true)}
@@ -76,7 +76,7 @@ export default function OwnerActionButtons({
           <button className="whop-dashboard-btn" onClick={openDashboard}>
             <FaTachometerAlt /> Dashboard
           </button>
-          {whopData.modules?.discord_access && (
+          {Boolean(whopData.modules?.discord_access) && (
             <button
               className="whop-discord-btn"
               onClick={() => setShowDiscordSetup(true)}

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -49,6 +49,14 @@ export default async function fetchWhopData(
     }
 
     const data = json.data;
+    if (data.modules && typeof data.modules === 'object') {
+      data.modules = Object.fromEntries(
+        Object.entries(data.modules).map(([k, v]) => [
+          k,
+          v === true || v === 1 || v === '1' || v === 'true',
+        ])
+      );
+    }
     setWhopData(data);
 
     // If owner, prepare editing state:


### PR DESCRIPTION
## Summary
- normalize `modules` flags to booleans when loading Whop data
- check Discord module flag with `Boolean()` in member and owner views

## Testing
- `CI=true npm test --silent -- --passWithNoTests -w 0`

------
https://chatgpt.com/codex/tasks/task_e_687b8c2274d4832c8aced05b6c4b1e74