### PR TITLE
Implement multi-pricing editing

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -67,6 +67,7 @@ export default function WhopDashboard() {
 
   // Feature-edit
   const [editFeatures, setEditFeatures] = useState([]);
+  const [editPricingPlans, setEditPricingPlans] = useState([]);
   const [editCourseSteps, setEditCourseSteps] = useState([
     { id: 1, title: "", content: "", fileUrl: "", fileType: "", isUploading: false, error: "" }
   ]);
@@ -131,6 +132,7 @@ export default function WhopDashboard() {
       setEditBannerUrl,
       setNewSlugValue,
       setEditFeatures,
+      setEditPricingPlans,
       fetchCampaignsBound,
       setWaitlistEnabled,
       setWaitlistQuestions,
@@ -246,6 +248,34 @@ export default function WhopDashboard() {
     setEditCourseSteps
   );
 
+  // Manage pricing plans
+  const addPlan = () => {
+    const newId =
+      editPricingPlans.length > 0
+        ? Math.max(...editPricingPlans.map(p => p.id || 0)) + 1
+        : 1;
+    setEditPricingPlans(prev => [
+      ...prev,
+      {
+        id: newId,
+        plan_name: "",
+        price: 0,
+        billing_period: "7 days",
+        currency: whopData?.currency || "USD",
+      },
+    ]);
+  };
+
+  const removePlan = id => {
+    setEditPricingPlans(prev => prev.filter(p => p.id !== id));
+  };
+
+  const handlePlanChange = (id, field, value) => {
+    setEditPricingPlans(prev =>
+      prev.map(p => (p.id === id ? { ...p, [field]: value } : p))
+    );
+  };
+
   // 8️⃣ Slug save
   const onSlugSave = async () => {
     await handleSlugSave(whopData, newSlugValue, showNotification, setSlugError, navigate);
@@ -259,12 +289,14 @@ export default function WhopDashboard() {
       editDescription,
       editBannerUrl,
       editFeatures,
+      editPricingPlans,
       showNotification,
       setError,
       setEditName,
       setEditDescription,
       setEditBannerUrl,
       setEditFeatures,
+      setEditPricingPlans,
       setSlugError,
       fetchCampaignsBound,
       setWhopData,
@@ -338,10 +370,11 @@ export default function WhopDashboard() {
         setWhopData,
         setEditName,
         setEditDescription,
-        setEditBannerUrl,
-        setNewSlugValue,
-        setEditFeatures,
-        fetchCampaignsBound,
+      setEditBannerUrl,
+      setNewSlugValue,
+      setEditFeatures,
+      setEditPricingPlans,
+      fetchCampaignsBound,
         setWaitlistEnabled,
         setWaitlistQuestions,
         setEditCourseSteps,

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -45,6 +45,10 @@ export default function OwnerMode({
   handleImageChange,
   removeFeature,
   addFeature,
+  editPricingPlans,
+  addPlan,
+  removePlan,
+  handlePlanChange,
   editCourseSteps,
   handleCourseChange,
   handleFileUpload,
@@ -82,6 +86,27 @@ export default function OwnerMode({
 }) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const containerRef = useRef(null);
+
+  // Open sidebar by default on desktop when editing
+  useEffect(() => {
+    if (isEditing) {
+      if (window.innerWidth > 768) setMobileMenuOpen(true);
+    } else {
+      setMobileMenuOpen(false);
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth > 768 && isEditing) {
+        setMobileMenuOpen(true);
+      } else if (window.innerWidth <= 768) {
+        setMobileMenuOpen(false);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isEditing]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -174,6 +199,10 @@ export default function OwnerMode({
           setNewSlugValue={setNewSlugValue}
           slugError={slugError}
           handleSlugSave={handleSlugSave}
+          editPricingPlans={editPricingPlans}
+          addPlan={addPlan}
+          removePlan={removePlan}
+          handlePlanChange={handlePlanChange}
         />
 
         {/* Owner action buttons */}

--- a/src/pages/WhopDashboard/components/OwnerSlugPrice.jsx
+++ b/src/pages/WhopDashboard/components/OwnerSlugPrice.jsx
@@ -12,6 +12,10 @@ export default function OwnerSlugPrice({
   setNewSlugValue,
   slugError,
   handleSlugSave,
+  editPricingPlans,
+  addPlan,
+  removePlan,
+  handlePlanChange,
 }) {
   if (!whopData) return null;
 
@@ -63,58 +67,97 @@ export default function OwnerSlugPrice({
       <div className="whop-price-section">
         {isEditing ? (
           <div className="price-edit-wrapper">
-            <div className="price-field">
-              <label>Price (e.g. 10.00)</label>
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                value={whopData.price ?? ""}
-                onChange={e => {
-                  const val = e.target.value;
-                  updateField("price", val !== "" ? parseFloat(val) : 0);
-                }}
-              />
-            </div>
-            <div className="price-field">
-              <label>Currency</label>
-              <input
-                type="text"
-                value={whopData.currency || "USD"}
-                onChange={e =>
-                  updateField("currency", e.target.value.toUpperCase())
-                }
-              />
-            </div>
-            <div className="price-field">
-              <label>Subscription</label>
-              <select
-                value={whopData.is_recurring ? "1" : "0"}
-                onChange={e =>
-                  updateField("is_recurring", parseInt(e.target.value, 10))
-                }
-              >
-                <option value="0">One-time</option>
-                <option value="1">Recurring</option>
-              </select>
-            </div>
-            {whopData.is_recurring && (
-              <div className="price-field">
-                <label>Billing period</label>
+            {editPricingPlans.length === 0 && (
+              <>
+                <div className="price-field">
+                  <label>Price (e.g. 10.00)</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={whopData.price ?? ""}
+                    onChange={e => {
+                      const val = e.target.value;
+                      updateField("price", val !== "" ? parseFloat(val) : 0);
+                    }}
+                  />
+                </div>
+                <div className="price-field">
+                  <label>Currency</label>
+                  <input
+                    type="text"
+                    value={whopData.currency || "USD"}
+                    onChange={e =>
+                      updateField("currency", e.target.value.toUpperCase())
+                    }
+                  />
+                </div>
+                <div className="price-field">
+                  <label>Subscription</label>
+                  <select
+                    value={whopData.is_recurring ? "1" : "0"}
+                    onChange={e =>
+                      updateField("is_recurring", parseInt(e.target.value, 10))
+                    }
+                  >
+                    <option value="0">One-time</option>
+                    <option value="1">Recurring</option>
+                  </select>
+                </div>
+                {whopData.is_recurring && (
+                  <div className="price-field">
+                    <label>Billing period</label>
+                    <select
+                      value={whopData.billing_period || ""}
+                      onChange={e =>
+                        updateField("billing_period", e.target.value)
+                      }
+                    >
+                      <option value="1 minute">1 minute</option>
+                      <option value="7 days">7 days</option>
+                      <option value="14 days">14 days</option>
+                      <option value="30 days">30 days</option>
+                      <option value="1 year">1 year</option>
+                    </select>
+                  </div>
+                )}
+              </>
+            )}
+
+            {editPricingPlans.map((p, idx) => (
+              <div key={p.id} className="price-field plan-field">
+                <label>Plan {idx + 1}</label>
+                <input
+                  type="text"
+                  value={p.plan_name}
+                  onChange={e => handlePlanChange(p.id, "plan_name", e.target.value)}
+                  placeholder="Name"
+                />
+                <input
+                  type="number"
+                  step="0.01"
+                  value={p.price}
+                  onChange={e => handlePlanChange(p.id, "price", e.target.value)}
+                />
+                <input
+                  type="text"
+                  value={p.currency}
+                  onChange={e => handlePlanChange(p.id, "currency", e.target.value.toUpperCase())}
+                  className="plan-currency"
+                />
                 <select
-                  value={whopData.billing_period || ""}
-                  onChange={e =>
-                    updateField("billing_period", e.target.value)
-                  }
+                  value={p.billing_period}
+                  onChange={e => handlePlanChange(p.id, "billing_period", e.target.value)}
                 >
-                  <option value="1 minute">1 minute</option>
                   <option value="7 days">7 days</option>
                   <option value="14 days">14 days</option>
                   <option value="30 days">30 days</option>
                   <option value="1 year">1 year</option>
                 </select>
+                <button onClick={() => removePlan(p.id)}>-</button>
               </div>
-            )}
+            ))}
+            <button className="add-plan-btn" onClick={addPlan}>Add Plan</button>
 
             {/* Waitlist toggle */}
             <div className="price-field">

--- a/src/pages/WhopDashboard/fetchWhopData.js
+++ b/src/pages/WhopDashboard/fetchWhopData.js
@@ -10,6 +10,7 @@ export default async function fetchWhopData(
   setEditBannerUrl,
   setNewSlugValue,
   setEditFeatures,
+  setEditPricingPlans,
   fetchCampaigns,        // bound version
   setWaitlistEnabled,    // newly added
   setWaitlistQuestions,  // newly added
@@ -75,6 +76,18 @@ export default async function fetchWhopData(
           isUploading: false,
           error: "",
         }))
+      );
+
+      setEditPricingPlans(
+        Array.isArray(data.pricing_plans)
+          ? data.pricing_plans.map(p => ({
+              id: p.id,
+              plan_name: p.plan_name || "",
+              price: p.price,
+              billing_period: p.billing_period,
+              currency: p.currency || data.currency,
+            }))
+          : []
       );
 
       const toAbsolute = url => {

--- a/src/pages/WhopDashboard/handleSaveWhop.js
+++ b/src/pages/WhopDashboard/handleSaveWhop.js
@@ -6,12 +6,14 @@ export default async function handleSaveWhop(
   editDescription,
   editBannerUrl,
   editFeatures,
+  editPricingPlans,
   showNotification,
   setError,
   setEditName,
   setEditDescription,
   setEditBannerUrl,
   setEditFeatures,
+  setEditPricingPlans,
   setSlugError,
   fetchCampaigns,
   setWhopData,
@@ -80,6 +82,14 @@ export default async function handleSaveWhop(
     faq:                editFaq,
     landing_texts:      editLandingTexts,
     modules:            editModules,
+    pricing_plans:     editPricingPlans.map((p, idx) => ({
+                          id: p.id,
+                          plan_name: p.plan_name,
+                          price: parseFloat(p.price) || 0,
+                          currency: p.currency || whopData.currency,
+                          billing_period: p.billing_period,
+                          sort_order: idx,
+                        })),
     affiliate_default_percent: parseFloat(editAffiliatePercent) || 0,
     affiliate_recurring: editAffiliateRecurring ? 1 : 0,
     course_steps:       editCourseSteps.map(s => ({
@@ -185,6 +195,18 @@ export default async function handleSaveWhop(
         error:       "",
       }));
       setEditFeatures(newFeatures);
+
+      setEditPricingPlans(
+        Array.isArray(data.pricing_plans)
+          ? data.pricing_plans.map(p => ({
+              id: p.id,
+              plan_name: p.plan_name || "",
+              price: p.price,
+              billing_period: p.billing_period,
+              currency: p.currency || data.currency,
+            }))
+          : []
+      );
 
       setEditCourseSteps(
         Array.isArray(data.course_steps) && data.course_steps.length


### PR DESCRIPTION
## Summary
- support editing multiple pricing plans
- keep owner text sidebar open on desktop
- wire pricing plan state through fetch/save handlers

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ba0d86ebc832caf7376131ecfdef9