### PR TITLE
Fix pricing plan props

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -496,6 +496,10 @@ export default function WhopDashboard() {
       handleImageChange={onFeatureImageUpload}
       removeFeature={removeFeature}
       addFeature={addFeature}
+      editPricingPlans={editPricingPlans}
+      addPlan={addPlan}
+      removePlan={removePlan}
+      handlePlanChange={handlePlanChange}
       editCourseSteps={editCourseSteps}
       handleCourseChange={handleCourseChange}
       handleFileUpload={onCourseFileUpload}


### PR DESCRIPTION
## Summary
- pass pricing plan props from `WhopDashboard` to `OwnerMode`

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba49b1ad0832c8e7e23491814dc62