### PR TITLE
Enable multi-plan join flow

### DIFF
--- a/src/pages/WhopDashboard/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard/WhopDashboard.jsx
@@ -108,6 +108,7 @@ export default function WhopDashboard() {
   // Member-mode tabs & loading
   const [activeTab, setActiveTab] = useState("Home");
   const [memberLoading, setMemberLoading] = useState(false);
+  const [selectedPlanId, setSelectedPlanId] = useState(null);
 
   // Owner “view as member”
   const [viewAsMemberMode, setViewAsMemberMode] = useState(false);
@@ -162,6 +163,14 @@ export default function WhopDashboard() {
     }
   }, [whopData]);
 
+  useEffect(() => {
+    if (Array.isArray(whopData?.pricing_plans) && whopData.pricing_plans.length > 0) {
+      setSelectedPlanId(whopData.pricing_plans[0].id);
+    } else {
+      setSelectedPlanId(null);
+    }
+  }, [whopData]);
+
   // 3️⃣ Fetch campaigns if owner or member
   useEffect(() => {
     if (whopData && (whopData.is_owner || whopData.is_member)) {
@@ -185,6 +194,7 @@ export default function WhopDashboard() {
     }
     await handleSubscribe(
       whopData,
+      selectedPlanId,
       showConfirm,
       setOverlayVisible,
       setOverlayFading,
@@ -462,6 +472,8 @@ export default function WhopDashboard() {
         handleSubscribe={onSubscribe}
         handleRequestWaitlist={onRequestWaitlist}
         showNotification={showNotification}
+        selectedPlanId={selectedPlanId}
+        setSelectedPlanId={setSelectedPlanId}
       />
     );
   }


### PR DESCRIPTION
## Summary
- allow handling multiple pricing plans in subscribe logic
- track selected pricing plan in dashboard state
- update landing page to let users choose a plan before joining

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ba6e3fc10832cbfb51faa47a2da72