### PR TITLE
Display all pricing plans

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -134,7 +134,8 @@ export default function Home() {
 }
 
 function Card({ item, index, visibleCount }) {
-  const isFree = item.price === 0;
+  const hasPlans = Array.isArray(item.pricing_plans) && item.pricing_plans.length > 0;
+  const isFree = item.price === 0 && !hasPlans;
   const visible = index < visibleCount;
   return (
     <Link to={`/c/${item.slug}`} className="whop-card-link">
@@ -163,10 +164,20 @@ function Card({ item, index, visibleCount }) {
           </div>
         </div>
         <div className="whop-tag">
-          {isFree
-            ? <span className="free-access">Free Access</span>
-            : <span>{item.currency}{item.price.toFixed(2)}{item.is_recurring ? ` / ${item.billing_period}` : ''}</span>
-          }
+          {isFree ? (
+            <span className="free-access">Free Access</span>
+          ) : hasPlans ? (
+            item.pricing_plans.map((p) => (
+              <span key={p.id}>
+                {(p.currency || item.currency)}{parseFloat(p.price).toFixed(2)}
+                {item.is_recurring ? ` / ${p.billing_period}` : ''}
+              </span>
+            ))
+          ) : (
+            <span>
+              {item.currency}{item.price.toFixed(2)}{item.is_recurring ? ` / ${item.billing_period}` : ''}
+            </span>
+          )}
         </div>
       </div>
     </Link>

--- a/src/pages/WhopDashboard.jsx
+++ b/src/pages/WhopDashboard.jsx
@@ -1324,17 +1324,22 @@ export default function WhopDashboard() {
           <p className="whop-landing-description">{whopData.description}</p>
 
           {Array.isArray(whopData.pricing_plans) && whopData.pricing_plans.length > 0 && (
-            <select
-              className="plan-select"
-              value={selectedPlanId || whopData.pricing_plans[0].id}
-              onChange={(e) => setSelectedPlanId(parseInt(e.target.value, 10))}
-            >
+            <div className="plan-options">
               {whopData.pricing_plans.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.plan_name || `${p.price}/${p.billing_period}`}
-                </option>
+                <button
+                  type="button"
+                  key={p.id}
+                  className={`plan-option${selectedPlanId === p.id ? ' selected' : ''}`}
+                  onClick={() => setSelectedPlanId(p.id)}
+                >
+                  <span className="plan-name">{p.plan_name || p.billing_period}</span>
+                  <span className="plan-price">
+                    {(p.currency || whopData.currency)}{parseFloat(p.price).toFixed(2)}
+                    {whopData.is_recurring ? `/${p.billing_period}` : ''}
+                  </span>
+                </button>
               ))}
-            </select>
+            </div>
           )}
 
           <button

--- a/src/pages/WhopDashboard/components/LandingPage.jsx
+++ b/src/pages/WhopDashboard/components/LandingPage.jsx
@@ -148,17 +148,22 @@ export default function LandingPage({
             <p className="long-desc">{long_description}</p>
           )}
           {Array.isArray(whopData.pricing_plans) && whopData.pricing_plans.length > 0 && (
-            <select
-              className="plan-select"
-              value={selectedPlanId || whopData.pricing_plans[0].id}
-              onChange={e => setSelectedPlanId(parseInt(e.target.value, 10))}
-            >
+            <div className="plan-options">
               {whopData.pricing_plans.map(p => (
-                <option key={p.id} value={p.id}>
-                  {p.plan_name || `${p.price}/${p.billing_period}`}
-                </option>
+                <button
+                  type="button"
+                  key={p.id}
+                  className={`plan-option${selectedPlanId === p.id ? ' selected' : ''}`}
+                  onClick={() => setSelectedPlanId(p.id)}
+                >
+                  <span className="plan-name">{p.plan_name || p.billing_period}</span>
+                  <span className="plan-price">
+                    {(p.currency || whopData.currency)}{parseFloat(p.price).toFixed(2)}
+                    {whopData.is_recurring ? `/${p.billing_period}` : ''}
+                  </span>
+                </button>
               ))}
-            </select>
+            </div>
           )}
           <div className="hero-buttons">
             <button

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -208,9 +208,12 @@
   }
 
   .whop-tag {
-          margin-top: 10px;
+    margin-top: 10px;
     flex: 0 0 auto;
     margin-left: var(--spacing-md);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-xxs);
 
     .free-access {
       padding: var(--spacing-xs) var(--spacing-sm);

--- a/src/styles/whop-dashboard/_landing.scss
+++ b/src/styles/whop-dashboard/_landing.scss
@@ -66,6 +66,46 @@
     line-height: 1.5;
     max-width: 700px;
   }
+
+  .plan-options {
+    display: flex;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: var(--spacing-sm);
+  }
+
+  .plan-option {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xxs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border: 1px solid var(--primary-color);
+    border-radius: var(--radius-base);
+    background: transparent;
+    color: var(--primary-color);
+    cursor: pointer;
+    font-size: 0.875rem;
+  }
+
+  .plan-option.selected {
+    background: var(--primary-color);
+    color: #fff;
+  }
+
+  .plan-option::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1px solid var(--primary-color);
+    background: transparent;
+    margin-right: var(--spacing-xxs);
+  }
+
+  .plan-option.selected::before {
+    background: var(--secondary-color);
+  }
   .whop-landing-join-btn {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- show pricing plan buttons instead of a `<select>` on whop landing pages
- indicate selected plan with a blue dot and highlight
- list multiple price tags on home page cards
- add styles for plan options and multiple tags

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687babb2404c832ca19e8cbce5bbe236