### PR TITLE
Fix CORS fetch and improve plan selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "whopv2",
   "version": "0.1.0",
   "private": true,
+  "proxy": "https://app.byxbot.com",
   "dependencies": {
     "@solana/web3.js": "^1.98.2",
     "@testing-library/dom": "^10.4.0",

--- a/src/components/SearchModal.jsx
+++ b/src/components/SearchModal.jsx
@@ -42,7 +42,7 @@ export default function SearchModal({ onClose }) {
     setLoading(true);
     const timer = setTimeout(() => {
       fetch(
-        `https://app.byxbot.com/php/search_whops.php?q=${encodeURIComponent(
+        `/php/search_whops.php?q=${encodeURIComponent(
           query.trim()
         )}`,
         {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,7 +3,8 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import '../styles/home.scss';
 
-const API_WHOPS_URL = 'https://app.byxbot.com/php/search_whops.php?all=1';
+// Use relative path so CRA proxy can avoid CORS issues in development
+const API_WHOPS_URL = '/php/search_whops.php?all=1';
 
 const FILTER_TAGS = [
   'Biggest revenue',

--- a/src/styles/whop-dashboard/_landing.scss
+++ b/src/styles/whop-dashboard/_landing.scss
@@ -81,18 +81,20 @@
     align-items: center;
     gap: var(--spacing-xxs);
     padding: var(--spacing-xs) var(--spacing-sm);
-    border: 1px solid var(--primary-color);
+    border: 1px solid var(--border-color);
     border-radius: var(--radius-base);
     background: transparent;
-    color: var(--primary-color);
+    color: var(--text-color);
     cursor: pointer;
     font-size: 0.875rem;
-    transition: background var(--transition), color var(--transition);
+    transition: background var(--transition), color var(--transition),
+      border-color var(--transition);
   }
 
   .plan-option.selected {
     background: var(--primary-color);
     color: #fff;
+    border-color: var(--primary-color);
     box-shadow: 0 0 0 2px var(--primary-color) inset;
   }
 
@@ -117,13 +119,15 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    border: 1px solid var(--primary-color);
+    border: 1px solid var(--border-color);
     background: transparent;
     margin-right: var(--spacing-xxs);
+    transition: background var(--transition), border-color var(--transition);
   }
 
   .plan-option.selected::before {
     background: var(--secondary-color);
+    border-color: var(--secondary-color);
   }
   .whop-landing-join-btn {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- configure CRA proxy to bypass CORS
- fetch Whop data through relative path
- update search modal to use relative path
- tweak plan selector styling with grey dot and blue on select

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687bb6dfbebc832c978b84d104304283