### PR TITLE
Fix pricing tags and improve plan selector

### DIFF
--- a/php/search_whops.php
+++ b/php/search_whops.php
@@ -41,7 +41,7 @@ try {
 }
 
 // =====================================
-// Pokud all=1, vr·tÌme vöechny whopy
+// Pokud all=1, vr√°t√≠me v¬öechny whopy
 // =====================================
 if (isset($_GET['all']) && $_GET['all'] === '1') {
     try {
@@ -74,7 +74,21 @@ if (isset($_GET['all']) && $_GET['all'] === '1') {
             )
             FROM whop_features AS f
             WHERE f.whop_id = w.id
-          ) AS features
+          ) AS features,
+          (
+            SELECT JSON_ARRAYAGG(
+              JSON_OBJECT(
+                'id', pp.id,
+                'plan_name', pp.plan_name,
+                'price', pp.price,
+                'currency', pp.currency,
+                'billing_period', pp.billing_period,
+                'sort_order', pp.sort_order
+              )
+            )
+            FROM whop_pricing_plans AS pp
+            WHERE pp.whop_id = w.id
+          ) AS pricing_plans
         FROM whops AS w
         LEFT JOIN payments AS p
           ON p.whop_id = w.id
@@ -100,7 +114,7 @@ if (isset($_GET['all']) && $_GET['all'] === '1') {
 }
 
 // =====================================
-// Fallback: pokud je zad·no q, hled·me
+// Fallback: pokud je zad√°no q, hled√°me
 // =====================================
 $q = trim($_GET['q'] ?? '');
 if ($q === '') {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -42,15 +42,34 @@ export default function Home() {
       try {
         const res = await fetch(API_WHOPS_URL, { credentials: 'include' });
         const json = await res.json();
-        setWhops(json.data.map(w => ({
-          ...w,
-          revenue:       parseFloat(w.revenue) || 0,
-          price:         parseFloat(w.price)   || 0,
-          members_count: parseInt(w.members_count, 10) || 0,
-          review_count:  parseInt(w.review_count, 10)  || 0,
-          features:      Array.isArray(w.features) ? w.features : [],
-          created_at:    w.created_at || null,
-        })));
+        setWhops(
+          json.data.map((w) => {
+            let features = [];
+            if (Array.isArray(w.features)) {
+              features = w.features;
+            } else if (w.features) {
+              try { features = JSON.parse(w.features); } catch {}
+            }
+
+            let plans = [];
+            if (Array.isArray(w.pricing_plans)) {
+              plans = w.pricing_plans;
+            } else if (w.pricing_plans) {
+              try { plans = JSON.parse(w.pricing_plans); } catch {}
+            }
+
+            return {
+              ...w,
+              revenue:       parseFloat(w.revenue) || 0,
+              price:         parseFloat(w.price)   || 0,
+              members_count: parseInt(w.members_count, 10) || 0,
+              review_count:  parseInt(w.review_count, 10)  || 0,
+              features,
+              pricing_plans: plans,
+              created_at:    w.created_at || null,
+            };
+          })
+        );
       } catch {
         setErrorMsg('Chyba při načítání.');
       } finally {

--- a/src/styles/whop-dashboard/_landing.scss
+++ b/src/styles/whop-dashboard/_landing.scss
@@ -78,33 +78,32 @@
   .plan-option {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-xxs);
-    padding: var(--spacing-xs) var(--spacing-sm);
-    border: 1px solid var(--primary-color);
-    border-radius: var(--radius-base);
-    background: transparent;
-    color: var(--primary-color);
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    background: var(--surface-color);
+    color: var(--text-color);
     cursor: pointer;
     font-size: 0.875rem;
   }
 
   .plan-option.selected {
-    background: var(--primary-color);
-    color: #fff;
+    border-color: var(--primary-color);
+    color: var(--primary-color);
   }
 
   .plan-option::before {
     content: "";
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
-    border: 1px solid var(--primary-color);
-    background: transparent;
-    margin-right: var(--spacing-xxs);
+    background: var(--border-color);
+    margin-right: var(--spacing-xs);
   }
 
   .plan-option.selected::before {
-    background: var(--secondary-color);
+    background: var(--primary-color);
   }
   .whop-landing-join-btn {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- parse pricing plans from search endpoint
- include pricing plans in `search_whops.php` results
- refine plan selection styles for whop landing pages

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bc7f9356c832c955902fda15a5509