### PR TITLE
Fix mobile back swipe

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,19 @@ import './styles/register.scss';
 import './styles/profile.scss';
 import './styles/notifications.scss';
 
+// Disable swipe navigation from the screen edges in mobile PWAs
+window.addEventListener(
+  'touchstart',
+  (e) => {
+    if (e.touches.length !== 1) return;
+    const x = e.touches[0].clientX;
+    if (x < 20 || x > window.innerWidth - 20) {
+      e.preventDefault();
+    }
+  },
+  { passive: false }
+);
+
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -15,6 +15,7 @@ html, body {
   color: var(--text-color);
   overflow-x: hidden;
   overscroll-behavior-x: none; // prevent browser back swipe on supported browsers
+  touch-action: pan-y; // disable horizontal swipe navigation
 }
 
 *,


### PR DESCRIPTION
## Summary
- disable horizontal swipe navigation by adding `touch-action: pan-y`
- prevent edge swipe from triggering browser history in the PWA

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687bd185e5c4832c87c6394abf4d3a06