### PR TITLE
Fix edge swipe navigation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,17 +17,16 @@ import './styles/profile.scss';
 import './styles/notifications.scss';
 
 // Disable swipe navigation from the screen edges in mobile PWAs
-window.addEventListener(
-  'touchstart',
-  (e) => {
-    if (e.touches.length !== 1) return;
-    const x = e.touches[0].clientX;
-    if (x < 20 || x > window.innerWidth - 20) {
-      e.preventDefault();
-    }
-  },
-  { passive: false }
-);
+const preventEdgeSwipe = (e) => {
+  if (e.touches.length !== 1) return;
+  const x = e.touches[0].clientX;
+  if (x < 20 || x > window.innerWidth - 20) {
+    e.preventDefault();
+  }
+};
+
+window.addEventListener('touchstart', preventEdgeSwipe, { passive: false });
+window.addEventListener('touchmove', preventEdgeSwipe, { passive: false });
 
 const container = document.getElementById('root');
 const root = createRoot(container);


### PR DESCRIPTION
## Summary
- stop browser back gestures from interfering with sidebar swipes by blocking touchstart and touchmove near the screen edges

## Testing
- `npm test` *(fails: No tests found)*
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd682cd30832ca86a54a223a22931