### PR TITLE
Add vibration feedback for mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import Loading from "./components/Loading";
 import MobileHeader from "./components/MobileHeader";
 import PageLoader from "./components/PageLoader";
+import useGlobalVibration from "./hooks/useGlobalVibration";
 
 const Home                 = lazy(() => import("./pages/Home"));
 const Intro                = lazy(() => import("./pages/Intro"));
@@ -31,6 +32,7 @@ const DiscordAccess        = lazy(() => import("./pages/DiscordAccess"));
 const DiscordAccessSetup   = lazy(() => import("./pages/DiscordAccessSetup"));
 
 const App = () => {
+  useGlobalVibration();
   const { isLoggedIn } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const toggleSidebar = () => setSidebarOpen((prev) => !prev);

--- a/src/hooks/useGlobalVibration.js
+++ b/src/hooks/useGlobalVibration.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+export default function useGlobalVibration() {
+  useEffect(() => {
+    const isMobile = typeof window !== 'undefined' &&
+      window.matchMedia('(any-pointer: coarse)').matches;
+    const canVibrate = typeof navigator !== 'undefined' &&
+      typeof navigator.vibrate === 'function';
+
+    if (!isMobile || !canVibrate) {
+      return;
+    }
+
+    const handleVibrate = e => {
+      const target = e.target.closest(
+        'button, a, [role="button"], input[type="button"], input[type="submit"]'
+      );
+      if (target) {
+        navigator.vibrate(30);
+      }
+    };
+
+    document.body.addEventListener('click', handleVibrate, true);
+    return () => {
+      document.body.removeEventListener('click', handleVibrate, true);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- create `useGlobalVibration` hook to add vibration feedback when clicking buttons or links on mobile devices
- enable the hook in `App.jsx`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687be53764b8832cbbaa7e108cb38816