### PR TITLE
Hide Discord sidebar item when module disabled

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMain.jsx
+++ b/src/pages/WhopDashboard/components/MemberMain.jsx
@@ -268,7 +268,7 @@ export default function MemberMain({
       )}
 
       {/* DISCORD */}
-      {activeTab === "Discord" && Boolean(whopData.modules?.discord_access) && (
+      {activeTab === "Discord" && whopData.modules?.discord_access === true && (
         <div className="member-tab-content">
           <h3 className="member-subtitle">Discord Access</h3>
           <p className="member-text">

--- a/src/pages/WhopDashboard/components/MemberSidebar.jsx
+++ b/src/pages/WhopDashboard/components/MemberSidebar.jsx
@@ -70,7 +70,7 @@ export default function MemberSidebar({
             <FaDollarSign /> Affiliate
           </button>
         )}
-        {Boolean(whopData.modules?.discord_access) && (
+        {whopData.modules?.discord_access === true && (
           <button
             className={`nav-button ${activeTab === "Discord" ? "active" : ""}`}
             onClick={() => setActiveTab("Discord")}

--- a/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
+++ b/src/pages/WhopDashboard/components/OwnerActionButtons.jsx
@@ -43,7 +43,7 @@ export default function OwnerActionButtons({
           >
             Cancel
           </button>
-          {Boolean(whopData.modules?.discord_access) && (
+          {whopData.modules?.discord_access === true && (
             <button
               className="whop-discord-btn"
               onClick={() => setShowDiscordSetup(true)}
@@ -76,7 +76,7 @@ export default function OwnerActionButtons({
           <button className="whop-dashboard-btn" onClick={openDashboard}>
             <FaTachometerAlt /> Dashboard
           </button>
-          {Boolean(whopData.modules?.discord_access) && (
+          {whopData.modules?.discord_access === true && (
             <button
               className="whop-discord-btn"
               onClick={() => setShowDiscordSetup(true)}


### PR DESCRIPTION
## Summary
- ensure Discord tab only appears when the Discord Access module is enabled
- update member main view and owner action buttons accordingly

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bebe34628832c8104ac6fd9a55c66