### PR TITLE
Replace swipe sidebars with arrow toggles

### DIFF
--- a/src/pages/WhopDashboard/components/MemberMode.jsx
+++ b/src/pages/WhopDashboard/components/MemberMode.jsx
@@ -1,6 +1,7 @@
 // src/pages/WhopDashboard/components/MemberMode.jsx
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
+import { FaChevronRight } from "react-icons/fa";
 import MemberSidebar from "./MemberSidebar";
 import MemberMain from "./MemberMain";
 import SubmissionPanel from "./SubmissionPanel";
@@ -20,54 +21,6 @@ export default function MemberMode({
   const [selectedCampaign, setSelectedCampaign] = useState(null);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const containerRef = useRef(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || window.innerWidth > 768) return;
-    let startX = null;
-    const getX = (ev) => (ev.touches ? ev.touches[0].clientX : ev.clientX);
-    const start = (e) => {
-      startX = getX(e);
-      const width = container.clientWidth;
-      // Ignore system back swipe by not starting from the very edge
-      if (startX < 20 || startX > width - 20) {
-        startX = null;
-      }
-    };
-    const move = (e) => {
-      if (startX === null) return;
-      const diff = getX(e) - startX;
-      if (!mobileSidebarOpen && diff > 50) {
-        setMobileSidebarOpen(true);
-        window.navigator.vibrate?.(20);
-        startX = null;
-      } else if (mobileSidebarOpen && diff < -50) {
-        setMobileSidebarOpen(false);
-        window.navigator.vibrate?.(20);
-        startX = null;
-      }
-      if (startX === null) {
-        e.preventDefault();
-      }
-    };
-    const end = () => {
-      startX = null;
-    };
-    container.addEventListener('touchstart', start, { passive: false });
-    container.addEventListener('touchmove', move, { passive: false });
-    container.addEventListener('touchend', end);
-    container.addEventListener('pointerdown', start, { passive: false });
-    container.addEventListener('pointermove', move, { passive: false });
-    container.addEventListener('pointerup', end);
-    return () => {
-      container.removeEventListener('touchstart', start);
-      container.removeEventListener('touchmove', move);
-      container.removeEventListener('touchend', end);
-      container.removeEventListener('pointerdown', start);
-      container.removeEventListener('pointermove', move);
-      container.removeEventListener('pointerup', end);
-    };
-  }, [mobileSidebarOpen]);
 
   // Callback to return from the submission panel
   const handleBackFromSubmission = () => {
@@ -93,6 +46,14 @@ export default function MemberMode({
           campaign={selectedCampaign}
           onBack={handleBackFromSubmission}
         />
+        <button
+          className="sidebar-toggle"
+          onClick={() => setMobileSidebarOpen((o) => !o)}
+          aria-label="Toggle sidebar"
+          type="button"
+        >
+          <FaChevronRight />
+        </button>
         <div
           className={`sidebar-overlay${mobileSidebarOpen ? ' visible' : ''}`}
           onClick={() => setMobileSidebarOpen(false)}
@@ -122,6 +83,14 @@ export default function MemberMode({
         onSelectCampaign={setSelectedCampaign}
         setWhopData={setWhopData}
       />
+      <button
+        className="sidebar-toggle"
+        onClick={() => setMobileSidebarOpen((o) => !o)}
+        aria-label="Toggle sidebar"
+        type="button"
+      >
+        <FaChevronRight />
+      </button>
       <div
         className={`sidebar-overlay${mobileSidebarOpen ? ' visible' : ''}`}
         onClick={() => setMobileSidebarOpen(false)}

--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -1,6 +1,7 @@
 // src/pages/WhopDashboard/components/OwnerMode.jsx
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
+import { FaArrowLeft, FaChevronLeft } from "react-icons/fa";
 import { FaArrowLeft } from "react-icons/fa";
 import "../../../styles/whop-dashboard/_owner.scss";
 
@@ -108,37 +109,6 @@ export default function OwnerMode({
     return () => window.removeEventListener('resize', handleResize);
   }, [isEditing]);
 
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || window.innerWidth > 768 || !isEditing) return;
-    let startX = null;
-    const getX = (ev) => (ev.touches ? ev.touches[0].clientX : ev.clientX);
-    const start = (e) => {
-      startX = getX(e);
-    };
-    const end = (e) => {
-      if (startX === null) return;
-      const diff = getX(e) - startX;
-      if (!mobileMenuOpen && diff < -50) {
-        setMobileMenuOpen(true);
-        window.navigator.vibrate?.(20);
-      } else if (mobileMenuOpen && diff > 50) {
-        setMobileMenuOpen(false);
-        window.navigator.vibrate?.(20);
-      }
-      startX = null;
-    };
-    container.addEventListener("touchstart", start);
-    container.addEventListener("touchend", end);
-    container.addEventListener("pointerdown", start);
-    container.addEventListener("pointerup", end);
-    return () => {
-      container.removeEventListener("touchstart", start);
-      container.removeEventListener("touchend", end);
-      container.removeEventListener("pointerdown", start);
-      container.removeEventListener("pointerup", end);
-    };
-  }, [mobileMenuOpen, isEditing]);
 
   if (!whopData) return null;
 
@@ -190,6 +160,16 @@ export default function OwnerMode({
           setEditLandingTexts={setEditLandingTexts}
           isMobileOpen={mobileMenuOpen}
         />
+      )}
+      {isEditing && (
+        <button
+          className="sidebar-toggle"
+          onClick={() => setMobileMenuOpen((o) => !o)}
+          aria-label="Toggle sidebar"
+          type="button"
+        >
+          <FaChevronLeft />
+        </button>
       )}
 
       <div className="whop-content">

--- a/src/styles/whop-dashboard/_member.scss
+++ b/src/styles/whop-dashboard/_member.scss
@@ -614,8 +614,10 @@
 
   .member-sidebar {
     position: fixed;
-    inset: 0;
-    width: 100%;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 75%;
     height: 100%;
     transform: translateX(-100%);
     visibility: hidden;
@@ -629,6 +631,30 @@
     transform: translateX(0);
     visibility: visible;
     opacity: 1;
+  }
+
+  .sidebar-toggle {
+    position: fixed;
+    top: 50%;
+    left: 0;
+    transform: translate(-50%, -50%);
+    z-index: 60;
+    background: var(--primary-color);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    transition: left var(--transition), transform var(--transition);
+  }
+
+  .member-container.sidebar-open .sidebar-toggle {
+    left: 75%;
+    transform: translate(-50%, -50%) rotate(180deg);
   }
 
   .sidebar-overlay {
@@ -681,6 +707,12 @@
     height: 8rem;
   }
   .member-sidebar {
-    width: 14rem;
+    width: 75%;
+  }
+}
+
+@media (min-width: 769px) {
+  .sidebar-toggle {
+    display: none;
   }
 }

--- a/src/styles/whop-dashboard/_owner.scss
+++ b/src/styles/whop-dashboard/_owner.scss
@@ -866,8 +866,10 @@
 
   .owner-text-menu {
     position: fixed;
-    inset: 0;
-    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 75%;
     height: 100%;
     transform: translateX(100%);
     visibility: hidden;
@@ -881,6 +883,30 @@
     transform: translateX(0);
     visibility: visible;
     opacity: 1;
+  }
+
+  .sidebar-toggle {
+    position: fixed;
+    top: 50%;
+    right: 0;
+    transform: translate(50%, -50%);
+    z-index: 60;
+    background: var(--primary-color);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    transition: right var(--transition), transform var(--transition);
+  }
+
+  .whop-container.menu-open .sidebar-toggle {
+    right: 75%;
+    transform: translate(50%, -50%) rotate(180deg);
   }
 
   .sidebar-overlay {
@@ -928,6 +954,10 @@
     &.closed {
       transform: translateX(100%);
     }
+  }
+
+  .sidebar-toggle {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- make member and owner sidebars open via toggle button instead of swipe
- style new sidebar toggles for both member and owner modes
- adjust responsive widths for new sidebar design

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bfa442bf4832c990250719b6cee5b