### PR TITLE
Fix OwnerMode duplicate imports

### DIFF
--- a/src/pages/WhopDashboard/components/OwnerMode.jsx
+++ b/src/pages/WhopDashboard/components/OwnerMode.jsx
@@ -1,8 +1,7 @@
 // src/pages/WhopDashboard/components/OwnerMode.jsx
 
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { FaArrowLeft, FaChevronLeft } from "react-icons/fa";
-import { FaArrowLeft } from "react-icons/fa";
 import "../../../styles/whop-dashboard/_owner.scss";
 
 import OwnerHeader from "./OwnerHeader";


### PR DESCRIPTION
## Summary
- fix duplicate `FaArrowLeft` import in `OwnerMode.jsx`
- add missing `useEffect` import

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bfdd89ce8832cb562405ed3c3ca22