### PR TITLE
Add MoonPay fiat deposit option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@moonpay/moonpay-js": "^0.7.3",
         "@solana/web3.js": "^1.98.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -2970,6 +2971,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@moonpay/moonpay-js": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@moonpay/moonpay-js/-/moonpay-js-0.7.3.tgz",
+      "integrity": "sha512-viLH7KqT0WKSrC9yWF+NYOV5DFr7XSkSftpeI9ze6BSeoLEA8lRpq0bik8OfpGSUxCbYQKvKbAgJTviRiGkyfQ==",
       "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@moonpay/moonpay-js": "^0.7.3",
     "@solana/web3.js": "^1.98.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/components/DepositModal.jsx
+++ b/src/components/DepositModal.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNotifications } from './NotificationProvider';
+import { loadMoonPay } from '@moonpay/moonpay-js';
 import '../styles/deposit-modal.scss';
 
 export default function DepositModal({ isOpen, onClose, onSuccess }) {
@@ -80,6 +81,28 @@ export default function DepositModal({ isOpen, onClose, onSuccess }) {
     );
   };
 
+  const handleFiatDeposit = async () => {
+    if (!depositAddress) return;
+    try {
+      const moonPay = await loadMoonPay();
+      const widget = moonPay({
+        flow: 'buy',
+        environment: 'sandbox',
+        params: {
+          apiKey: 'REPLACE_WITH_PUBLIC_API_KEY',
+          currencyCode: 'sol',
+          walletAddress: depositAddress,
+          redirectURL: window.location.origin + '/balances',
+        },
+        variant: 'overlay',
+      });
+      widget.show();
+    } catch (err) {
+      console.error('MoonPay widget error:', err);
+      showNotification({ type: 'error', message: 'Unable to start MoonPay.' });
+    }
+  };
+
   if (!isOpen) return null;
 
   return (
@@ -118,6 +141,12 @@ export default function DepositModal({ isOpen, onClose, onSuccess }) {
                 </li>
                 <li>Wait approximately 30 s for the transaction to process.</li>
               </ul>
+            </div>
+
+            <div className="dm-fiat-row">
+              <button className="dm-fiat-btn" onClick={handleFiatDeposit}>
+                Buy with Fiat
+              </button>
             </div>
 
             <div className="dm-close-row">

--- a/src/styles/deposit-modal.scss
+++ b/src/styles/deposit-modal.scss
@@ -120,4 +120,23 @@
       }
     }
   }
+
+  .dm-fiat-row {
+    text-align: center;
+    margin-top: var(--spacing-md);
+
+    .dm-fiat-btn {
+      background: var(--primary-color);
+      color: #fff;
+      border: none;
+      border-radius: var(--radius-base);
+      padding: var(--spacing-xs) var(--spacing-lg);
+      cursor: pointer;
+      transition: background var(--transition);
+
+      &:hover {
+        background: var(--primary-hover);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add `@moonpay/moonpay-js` dependency
- implement MoonPay integration in `DepositModal`
- style button to buy SOL using fiat

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687e7bc025c0832c9f40bc492d9eebae