### PR TITLE
Add MoonPay failure notification

### DIFF
--- a/src/pages/Balances.jsx
+++ b/src/pages/Balances.jsx
@@ -19,6 +19,18 @@ export default function Balances() {
   const [historyData, setHistoryData] = useState([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
 
+  // Check MoonPay redirect params on initial load
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const txStatus = params.get('transactionStatus');
+    if (txStatus === 'failed') {
+      showNotification({
+        type: 'error',
+        message: 'MoonPay transaction failed. Please try again later.',
+      });
+    }
+  }, [showNotification]);
+
   // Load current balance on mount
   useEffect(() => {
     setLoadingBalance(true);


### PR DESCRIPTION
## Summary
- show an error message on the Balances page if MoonPay redirected with `transactionStatus=failed`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e8913c72c832c9e5b4e3355e81378