### PR TITLE
Add payment process intermediate page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ const Memberships          = lazy(() => import("./pages/Memberships"));
 const Payments             = lazy(() => import("./pages/Payments"));
 const DiscordAccess        = lazy(() => import("./pages/DiscordAccess"));
 const DiscordAccessSetup   = lazy(() => import("./pages/DiscordAccessSetup"));
+const PaymentProcess       = lazy(() => import("./pages/PaymentProcess"));
 
 const App = () => {
   useGlobalVibration();
@@ -44,6 +45,7 @@ const App = () => {
           {/* Public routes */}
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
+          <Route path="/pay/:slug" element={<PaymentProcess />} />
 
           {/* Intro page */}
           <Route

--- a/src/pages/PaymentProcess.jsx
+++ b/src/pages/PaymentProcess.jsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { useNotifications } from "../components/NotificationProvider";
+import "../styles/payment-process.scss";
+
+export default function PaymentProcess() {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { showNotification } = useNotifications();
+
+  const [whopData, setWhopData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const search = new URLSearchParams(location.search);
+  const planId = search.get("plan");
+  const action = search.get("action") || "join"; // join | waitlist
+
+  useEffect(() => {
+    async function fetchWhop() {
+      try {
+        const res = await fetch(
+          `https://app.byxbot.com/php/get_whop.php?slug=${encodeURIComponent(slug)}`,
+          { credentials: "include" }
+        );
+        const json = await res.json();
+        if (res.ok && json.status === "success") {
+          setWhopData(json.data);
+        } else {
+          showNotification({ type: "error", message: json.message || "Failed to load." });
+        }
+      } catch (err) {
+        showNotification({ type: "error", message: "Network error." });
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchWhop();
+  }, [slug, showNotification]);
+
+  const price = (() => {
+    if (!whopData) return 0;
+    if (planId && Array.isArray(whopData.pricing_plans)) {
+      const p = whopData.pricing_plans.find(pl => pl.id === parseInt(planId));
+      return p ? parseFloat(p.price) : parseFloat(whopData.price);
+    }
+    return parseFloat(whopData.price);
+  })();
+  const currency = (() => {
+    if (!whopData) return "";
+    if (planId && Array.isArray(whopData.pricing_plans)) {
+      const p = whopData.pricing_plans.find(pl => pl.id === parseInt(planId));
+      return p ? p.currency || whopData.currency : whopData.currency;
+    }
+    return whopData.currency;
+  })();
+  const billingPeriod = (() => {
+    if (!whopData) return "";
+    if (planId && Array.isArray(whopData.pricing_plans)) {
+      const p = whopData.pricing_plans.find(pl => pl.id === parseInt(planId));
+      return p ? p.billing_period : whopData.billing_period;
+    }
+    return whopData.billing_period;
+  })();
+
+  const isRecurring = whopData && whopData.is_recurring;
+
+  async function handlePay() {
+    if (!whopData) return;
+    setSubmitting(true);
+    try {
+      if (action === "waitlist") {
+        const res = await fetch("https://app.byxbot.com/php/request_waitlist.php", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ whop_id: whopData.id, answers: [] })
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.message || "Error");
+        showNotification({ type: "success", message: json.message || "Request sent." });
+      } else if (!price || price <= 0) {
+        const res = await fetch("https://app.byxbot.com/php/join_whop.php", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ whop_id: whopData.id })
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.message || "Error");
+        showNotification({ type: "success", message: json.message || "Joined" });
+      } else {
+        const payload = { whop_id: whopData.id };
+        if (planId) payload.plan_id = parseInt(planId);
+        const res = await fetch("https://app.byxbot.com/php/subscribe_whop.php", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(payload)
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.message || "Error");
+        showNotification({ type: "success", message: json.message || "Subscribed" });
+      }
+      navigate(`/c/${slug}`);
+    } catch (err) {
+      if (err.message) {
+        showNotification({ type: "error", message: err.message });
+      } else {
+        showNotification({ type: "error", message: "Network error" });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="payment-process-container"><p>Loading…</p></div>;
+  }
+  if (!whopData) {
+    return <div className="payment-process-container"><p>Unable to load payment info.</p></div>;
+  }
+
+  return (
+    <div className="payment-process-container">
+      <h2>{whopData.name}</h2>
+      <div className="payment-summary">
+        <p>Price: {currency}{price.toFixed(2)}</p>
+        {action !== "waitlist" && isRecurring ? (
+          <p>Renews every {billingPeriod}</p>
+        ) : null}
+        {action === "waitlist" && <p>Waitlist request (no charge)</p>}
+        <p>Fee: 0</p>
+        <p className="total">Total: {currency}{price.toFixed(2)}</p>
+      </div>
+      <div className="payment-actions">
+        <button className="btn-cancel btn" onClick={() => navigate(`/c/${slug}`)} disabled={submitting}>Cancel</button>
+        <button className="btn-confirm btn" onClick={handlePay} disabled={submitting}>{submitting ? 'Processing…' : 'Pay'}</button>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/payment-process.scss
+++ b/src/styles/payment-process.scss
@@ -1,0 +1,60 @@
+@import './design-system';
+
+.payment-process-container {
+  max-width: 480px;
+  margin: 40px auto;
+  padding: var(--spacing-lg);
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  color: var(--text-color);
+  text-align: center;
+}
+
+.payment-summary {
+  margin: var(--spacing-md) 0;
+  text-align: left;
+  line-height: 1.6;
+}
+
+.payment-summary .total {
+  margin-top: var(--spacing-md);
+  font-weight: 600;
+  font-size: 1.2rem;
+}
+
+.payment-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-lg);
+}
+
+.payment-actions .btn {
+  flex: 1;
+  padding: var(--spacing-sm);
+  border: none;
+  border-radius: var(--radius-base);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-cancel {
+  background: var(--error-color);
+  color: #fff;
+  margin-right: var(--spacing-sm);
+}
+
+.btn-confirm {
+  background: var(--success-color);
+  color: #fff;
+  margin-left: var(--spacing-sm);
+}
+
+.btn-confirm:hover {
+  background: var(--success-dark);
+}
+
+.btn-cancel:hover {
+  background: var(--error-dark);
+}


### PR DESCRIPTION
## Summary
- create `PaymentProcess` page for payment confirmation
- route `/pay/:slug` loads payment info and lets user confirm
- style intermediate page with new SCSS

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fe34693c8832ca378fee5d5047445