### PR TITLE
Replace Onramper with Kado

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@moonpay/moonpay-js": "^0.7.3",
         "@solana/web3.js": "^1.98.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -2971,12 +2970,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "license": "MIT"
-    },
-    "node_modules/@moonpay/moonpay-js": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@moonpay/moonpay-js/-/moonpay-js-0.7.3.tgz",
-      "integrity": "sha512-viLH7KqT0WKSrC9yWF+NYOV5DFr7XSkSftpeI9ze6BSeoLEA8lRpq0bik8OfpGSUxCbYQKvKbAgJTviRiGkyfQ==",
       "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@moonpay/moonpay-js": "^0.7.3",
     "@solana/web3.js": "^1.98.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/components/DepositModal.jsx
+++ b/src/components/DepositModal.jsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNotifications } from './NotificationProvider';
-import { loadMoonPay } from '@moonpay/moonpay-js';
 import '../styles/deposit-modal.scss';
 
 export default function DepositModal({ isOpen, onClose, onSuccess }) {
@@ -81,25 +80,23 @@ export default function DepositModal({ isOpen, onClose, onSuccess }) {
     );
   };
 
-  const handleFiatDeposit = async () => {
+  const handleFiatDeposit = () => {
     if (!depositAddress) return;
     try {
-      const moonPay = await loadMoonPay();
-      const widget = moonPay({
-        flow: 'buy',
-        environment: 'sandbox',
-        params: {
-          apiKey: 'pk_test_cYWn5MAnEliQ7eM9OFT9d0Tj6bT1Ika',
-          currencyCode: 'sol',
-          walletAddress: depositAddress,
-          redirectURL: window.location.origin + '/balances',
-        },
-        variant: 'overlay',
-      });
-      widget.show();
+      const widgetUrl =
+        'https://app.kado.money' +
+        `/?apiKey=YOUR_KADO_API_KEY` +
+        `&product=BUY` +
+        `&onToNetwork=SOL` +
+        `&onToAddress=${encodeURIComponent(depositAddress)}` +
+        `&redirectURL=${encodeURIComponent(window.location.origin + '/balances')}`;
+      const popup = window.open(widgetUrl, '_blank', 'width=500,height=750');
+      if (!popup) {
+        showNotification({ type: 'error', message: 'Popup blocked.' });
+      }
     } catch (err) {
-      console.error('MoonPay widget error:', err);
-      showNotification({ type: 'error', message: 'Unable to start MoonPay.' });
+      console.error('Kado widget error:', err);
+      showNotification({ type: 'error', message: 'Unable to start Kado.' });
     }
   };
 

--- a/src/pages/Balances.jsx
+++ b/src/pages/Balances.jsx
@@ -19,14 +19,14 @@ export default function Balances() {
   const [historyData, setHistoryData] = useState([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
 
-  // Check MoonPay redirect params on initial load
+  // Check deposit redirect params on initial load
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const txStatus = params.get('transactionStatus');
     if (txStatus === 'failed') {
       showNotification({
         type: 'error',
-        message: 'MoonPay transaction failed. Please try again later.',
+        message: 'Deposit transaction failed. Please try again later.',
       });
     }
   }, [showNotification]);


### PR DESCRIPTION
## Summary
- update deposit modal to open Kado widget
- generalize deposit redirect check message

## Testing
- `npm ci --silent`
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68827027d680832c9d32ea0464f7f61c