### PR TITLE
Fix mobile sidebar scroll

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -20,6 +20,7 @@ body {
   background-color: var(--bg-color);
   color: var(--text-color);
   overflow: hidden; // prevent double scrollbars
+  overscroll-behavior: none; // avoid page bounce on mobile
 }
 
 .app-container {
@@ -33,6 +34,8 @@ body {
   flex: 1;
   padding: 20px;
   overflow-y: auto;
+  overscroll-behavior: contain; // keep scroll inside
+  -webkit-overflow-scrolling: touch;
 }
 
 ul {

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -118,4 +118,6 @@ textarea:focus {
   padding: var(--spacing-lg); /* Standard padding on top/side */
   padding-bottom: calc(var(--spacing-lg) + var(--bottombar-height)); /* Space below to avoid overlap with the bottom bar */
   overflow-y: auto; /* Vertical scroll inside main-content */
+  overscroll-behavior: contain; /* Prevent body scroll when reaching edges */
+  -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
 }

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -14,6 +14,9 @@
   padding: var(--spacing-md);
   z-index: 50;
   transition: all 0.3s ease;
+  overflow-y: auto;               // allow scrolling inside the sidebar
+  overscroll-behavior: contain;   // prevent body scroll when at edges
+  -webkit-overflow-scrolling: touch; // smooth scrolling on iOS
 
   // MOBILE CLOSED
   &.closed {


### PR DESCRIPTION
## Summary
- allow scrolling inside the sidebar and prevent body scroll bleed
- avoid page bounce and overscroll on mobile

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883a4782bb0832cb8b9c6f311dfb2d8