### PR TITLE
Improve mobile layout for whop cards

### DIFF
--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -260,6 +260,15 @@
   .whop-content {
     margin-left: 0;
     margin-top: var(--spacing-sm);
+
+    .whop-title {
+      font-size: 0.8rem;
+    }
+
+    .whop-desc {
+      font-size: 0.7rem;
+      line-height: 1.1;
+    }
   }
 
   .whop-tag {


### PR DESCRIPTION
## Summary
- revert previous height expansion fix
- reduce whop card text sizes on small screens so content fits in fixed-height cards

## Testing
- `npm ci`
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6883a73fe78c832c960d304ef5e9049f