### PR TITLE
Fix Jupiter swap with correct USDC mint

### DIFF
--- a/solana-monitor/monitor.js
+++ b/solana-monitor/monitor.js
@@ -87,7 +87,9 @@ async function getSolPriceUsd() {
 // 2.1) Převod SOL -> USDC přes Jupiter API
 // ---------------------------------------------
 const SOL_MINT  = 'So11111111111111111111111111111111111111112';
-const USDC_MINT = '7rbvUFP8s5eyL9ddi3bDTancoC8NQx7Z1iQg76u1JaSm'; // Devnet USDC
+// Correct devnet USDC mint. Previous mint 7rbvUFP8s5eyL9ddi3bDTancoC8NQx7Z1iQg76u1JaSm
+// is not tradable on Jupiter and resulted in missing swap routes.
+const USDC_MINT = '7kbnvuGBxxj8AG9qp8Scn56muWGaRaFqxg1FsRp3PaFT';
 async function swapSolToUsdc(lamportsAmount) {
   try {
     const quoteUrl =

--- a/solana-monitor/withdraw.js
+++ b/solana-monitor/withdraw.js
@@ -16,7 +16,9 @@ import {
 } from '@solana/web3.js';
 
 const SOL_MINT  = 'So11111111111111111111111111111111111111112';
-const USDC_MINT = '7rbvUFP8s5eyL9ddi3bDTancoC8NQx7Z1iQg76u1JaSm'; // Devnet USDC
+// Correct devnet USDC mint. The previous value 7rbvUFP8s5eyL9ddi3bDTancoC8NQx7Z1iQg76u1JaSm
+// is not supported by Jupiter and prevented swaps.
+const USDC_MINT = '7kbnvuGBxxj8AG9qp8Scn56muWGaRaFqxg1FsRp3PaFT';
 const FEE_LAMPORTS = 5000; // estimated tx fee
 
 async function swapUsdcToSol(lamportsNeeded, connection, keypair) {


### PR DESCRIPTION
## Summary
- use the proper USDC mint address on devnet for Jupiter swaps in monitor and withdraw scripts

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883cee834d0832cae6f0c32af1e985c